### PR TITLE
Migrate LazyVim extras to lazyvim.json

### DIFF
--- a/.config/lazyvim/lazyvim.json
+++ b/.config/lazyvim/lazyvim.json
@@ -1,7 +1,18 @@
 {
   "extras": [
     "lazyvim.plugins.extras.ai.copilot",
-    "lazyvim.plugins.extras.coding.mini-surround"
+    "lazyvim.plugins.extras.coding.mini-surround",
+    "lazyvim.plugins.extras.editor.telescope",
+    "lazyvim.plugins.extras.lang.docker",
+    "lazyvim.plugins.extras.lang.git",
+    "lazyvim.plugins.extras.lang.json",
+    "lazyvim.plugins.extras.lang.markdown",
+    "lazyvim.plugins.extras.lang.python",
+    "lazyvim.plugins.extras.lang.tailwind",
+    "lazyvim.plugins.extras.lang.toml",
+    "lazyvim.plugins.extras.lang.typescript",
+    "lazyvim.plugins.extras.lang.yaml",
+    "lazyvim.plugins.extras.util.dot"
   ],
   "news": {
     "NEWS.md": "11866"

--- a/.config/lazyvim/lua/config/lazy.lua
+++ b/.config/lazyvim/lua/config/lazy.lua
@@ -18,20 +18,6 @@ require("lazy").setup({
   spec = {
     -- add LazyVim and import its plugins
     { "LazyVim/LazyVim", import = "lazyvim.plugins" },
-    -- load lazyvim editor extras
-    { import = "lazyvim.plugins.extras.editor.telescope" },
-    -- load lazyvim lang extras
-    { import = "lazyvim.plugins.extras.lang.python" },
-    { import = "lazyvim.plugins.extras.lang.yaml" },
-    { import = "lazyvim.plugins.extras.lang.typescript" },
-    { import = "lazyvim.plugins.extras.lang.toml" },
-    { import = "lazyvim.plugins.extras.lang.tailwind" },
-    { import = "lazyvim.plugins.extras.lang.markdown" },
-    { import = "lazyvim.plugins.extras.lang.json" },
-    { import = "lazyvim.plugins.extras.lang.git" },
-    { import = "lazyvim.plugins.extras.lang.docker" },
-    -- load lazyvim util extras
-    { import = "lazyvim.plugins.extras.util.dot" },
     -- import/override with your plugins
     { import = "plugins" },
   },


### PR DESCRIPTION
## Summary
- Moved 11 hardcoded `{ import = "..." }` extras from `lazy.lua` into `lazyvim.json` so they're manageable via `:LazyExtras`
- Removed redundant import lines from `lua/config/lazy.lua`

## Test plan
- [x] Verified `lazyvim.json` contains all 13 extras
- [x] Confirmed `nvim` loads plugins successfully (9/46 eager, rest lazy-loaded)
- [x] Ran `:checkhealth` — no new errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)