### PR TITLE
Enable OSC 52 clipboard over SSH/Mosh

### DIFF
--- a/.config/lazyvim/lua/config/options.lua
+++ b/.config/lazyvim/lua/config/options.lua
@@ -14,3 +14,6 @@ vim.g.lazyvim_picker = "telescope"
 vim.g.lazyvim_python_lsp = "pyright"
 -- Set to "ruff_lsp" to use the old LSP implementation version.
 vim.g.lazyvim_python_ruff = "ruff"
+
+-- Enable clipboard over SSH via OSC 52
+vim.opt.clipboard = "unnamedplus"

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -6,6 +6,9 @@ set -g default-terminal "xterm-256color"
 # https://stackoverflow.com/a/60313682/3112403
 set-option -ga terminal-overrides ",xterm-256color:Tc"
 
+# Enable OSC 52 clipboard (tmux copy-mode emits OSC 52, inner apps forwarded)
+set -s set-clipboard on
+
 # Change prefix key to C-a, easier to type, same to "screen"
 unbind C-b
 set -g prefix C-a


### PR DESCRIPTION
## Summary

- Set tmux `set-clipboard on` so tmux copy-mode emits OSC 52 and inner apps (Neovim) are forwarded to the outer terminal
- Set Neovim `clipboard = "unnamedplus"` to override LazyVim's SSH default (`""`), routing yanks through the built-in OSC 52 provider

**Chain:** Neovim → tmux → SSH/Mosh → Alacritty (local) → macOS clipboard

## Test plan

- [ ] In tmux copy-mode, select text and yank — verify `Cmd+V` pastes on local Mac
- [ ] In Neovim, yank a line (`yy`) — verify `Cmd+V` pastes on local Mac
- [ ] If Neovim yanks don't reach clipboard, add `vim.g.clipboard = 'osc52'` as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)