### PR TITLE
Add missing TPM plugin declarations

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -111,6 +111,8 @@ set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'dracula/tmux'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-yank'
+set -g @plugin 'christoomey/vim-tmux-navigator'
+set -g @plugin 'b0o/tmux-autoreload'
 
 # tmux-yank: stay in copy mode after yanking (matches previous copy-pipe behavior)
 set -g @yank_action 'copy-pipe'


### PR DESCRIPTION
## Summary
- Added `set -g @plugin` declarations for `vim-tmux-navigator` and `tmux-autoreload` to `~/.tmux.conf`
- Both plugins were already installed in `~/.tmux/plugins/` but missing from the TPM config

## Test plan
- [ ] Reload tmux config (`C-a r`) and verify plugins still work
- [ ] Run `Prefix + U` to confirm TPM recognizes both plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)