### PR TITLE
Add F12 toggle for nested tmux sessions

### DIFF
--- a/.config/tmux/refresh-status.sh
+++ b/.config/tmux/refresh-status.sh
@@ -9,9 +9,7 @@ while IFS= read -r pid; do
             tmux set -g prefix C-b
             tmux unbind C-a
             tmux bind C-b send-prefix
-            # Clear Dracula's CPU/RAM widgets but preserve the nested-session
-            # OFF indicator (see ~/.tmux.conf). When key-table is normal, #()
-            # outputs nothing so status-right appears empty (same as before).
+            # Hide Dracula widgets but keep nested-session OFF indicator (see ~/.tmux.conf)
             tmux set -g status-right "#[fg=#f8f8f2,bg=#ff5555,bold]#([ \$(tmux show-option -qv key-table) = 'off' ] && echo ' OFF ')#[default]"
             exit 0
         fi

--- a/.config/tmux/refresh-status.sh
+++ b/.config/tmux/refresh-status.sh
@@ -9,7 +9,10 @@ while IFS= read -r pid; do
             tmux set -g prefix C-b
             tmux unbind C-a
             tmux bind C-b send-prefix
-            tmux set -g status-right "#[fg=#ff5555,bold]#([ \$(tmux show-option -qv key-table) = 'off' ] && echo ' OFF ')#[default]"
+            # Clear Dracula's CPU/RAM widgets but preserve the nested-session
+            # OFF indicator (see ~/.tmux.conf). When key-table is normal, #()
+            # outputs nothing so status-right appears empty (same as before).
+            tmux set -g status-right "#[fg=#f8f8f2,bg=#ff5555,bold]#([ \$(tmux show-option -qv key-table) = 'off' ] && echo ' OFF ')#[default]"
             exit 0
         fi
         p=$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')

--- a/.config/tmux/refresh-status.sh
+++ b/.config/tmux/refresh-status.sh
@@ -9,7 +9,7 @@ while IFS= read -r pid; do
             tmux set -g prefix C-b
             tmux unbind C-a
             tmux bind C-b send-prefix
-            tmux set -g status-right ""
+            tmux set -g status-right "#[fg=#ff5555,bold]#([ \$(tmux show-option -qv key-table) = 'off' ] && echo ' OFF ')#[default]"
             exit 0
         fi
         p=$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')

--- a/.config/tmux/refresh-status.sh
+++ b/.config/tmux/refresh-status.sh
@@ -9,8 +9,7 @@ while IFS= read -r pid; do
             tmux set -g prefix C-b
             tmux unbind C-a
             tmux bind C-b send-prefix
-            # Hide Dracula widgets but keep nested-session OFF indicator (see ~/.tmux.conf)
-            tmux set -g status-right "#[fg=#f8f8f2,bg=#ff5555,bold]#([ \$(tmux show-option -qv key-table) = 'off' ] && echo ' OFF ')#[default]"
+            tmux set -g status-right ""
             exit 0
         fi
         p=$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -119,7 +119,7 @@ set -g @yank_action 'copy-pipe'
 
 # configure theme
 set -g @dracula-show-powerline true
-set -g @dracula-plugins "cpu-usage ram-usage"
+set -g @dracula-plugins "cpu-usage ram-usage attached-clients ssh-session"
 set -g @dracula-show-flags true
 set -g @dracula-show-left-icon "#S#{?#{==:#{client_key_table},off}, 🚫,}"
 set -g @dracula-left-icon-padding 0

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -136,3 +136,29 @@ run '~/.tmux/plugins/tpm/tpm'
 # Adapt prefix and status bar for mosh sessions (restore: tmux source ~/.tmux.conf)
 set-hook -g client-attached 'run-shell "~/.config/tmux/refresh-status.sh"'
 run-shell '~/.config/tmux/refresh-status.sh'
+
+# === Nested session support: F12 toggles this tmux "off" ===
+
+# Append OFF indicator to status-right (shows only when key-table is 'off')
+set -ga status-right "#[fg=#ff5555,bold]#([ $(tmux show-option -qv key-table) = 'off' ] && echo ' OFF ')#[default]"
+
+# Toggle OFF: disable this tmux, pass keys to inner session
+bind -T root F12 \
+    set prefix None \;\
+    set key-table off \;\
+    set status-style "fg=#6272a4,bg=#282a36" \;\
+    set window-status-current-format "#[fg=#6272a4,bg=#44475a] #I #W #[default]" \;\
+    set window-status-format "#[fg=#6272a4,bg=#282a36] #I #W " \;\
+    set status-left "#[fg=#6272a4,bg=#282a36] #S " \;\
+    if -F '#{pane_in_mode}' 'send-keys -X cancel' \;\
+    refresh-client -S \;
+
+# Toggle ON: restore this tmux to normal operation
+bind -T off F12 \
+    set -u prefix \;\
+    set -u key-table \;\
+    set -u status-style \;\
+    set -u window-status-current-format \;\
+    set -u window-status-format \;\
+    set -u status-left \;\
+    refresh-client -S

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -138,27 +138,34 @@ set-hook -g client-attached 'run-shell "~/.config/tmux/refresh-status.sh"'
 run-shell '~/.config/tmux/refresh-status.sh'
 
 # === Nested session support: F12 toggles this tmux "off" ===
+# When SSH/Mosh-ing from a local Mac (which runs its own tmux) into this
+# remote server (also running tmux), both sessions compete for the same
+# prefix key. F12 disables the outer (remote) tmux so all keys pass through
+# to the inner (local) session. Pressing F12 again re-enables it.
+#
+# The OFF toggle uses `set` (session-level overrides), and the ON toggle
+# uses `set -u` (unset session-level), so global values set by Dracula
+# and refresh-status.sh are never touched and restore cleanly.
+#
+# Reference: https://www.freecodecamp.org/news/tmux-in-practice-local-and-nested-remote-tmux-sessions-4f7ba5db8795/
 
-# Append OFF indicator to status-right (shows only when key-table is 'off')
-set -ga status-right "#[fg=#ff5555,bold]#([ $(tmux show-option -qv key-table) = 'off' ] && echo ' OFF ')#[default]"
+# Append OFF indicator to status-right. The #() command substitution checks
+# the current key-table: outputs nothing in normal mode, shows white-on-red
+# "OFF" badge when key-table is 'off'.
+set -ga status-right "#[fg=#f8f8f2,bg=#ff5555,bold]#([ $(tmux show-option -qv key-table) = 'off' ] && echo ' OFF ')#[default]"
 
-# Toggle OFF: disable this tmux, pass keys to inner session
+# Toggle OFF: set prefix to None so no key combo activates tmux, and switch
+# to the 'off' key-table so all keys pass through to the inner session.
+# Also cancels copy-mode if active, since it would be unusable without prefix.
 bind -T root F12 \
     set prefix None \;\
     set key-table off \;\
-    set status-style "fg=#6272a4,bg=#282a36" \;\
-    set window-status-current-format "#[fg=#6272a4,bg=#44475a] #I #W #[default]" \;\
-    set window-status-format "#[fg=#6272a4,bg=#282a36] #I #W " \;\
-    set status-left "#[fg=#6272a4,bg=#282a36] #S " \;\
     if -F '#{pane_in_mode}' 'send-keys -X cancel' \;\
     refresh-client -S \;
 
-# Toggle ON: restore this tmux to normal operation
+# Toggle ON: unset session-level overrides to reveal the global values
+# that Dracula and refresh-status.sh originally configured.
 bind -T off F12 \
     set -u prefix \;\
     set -u key-table \;\
-    set -u status-style \;\
-    set -u window-status-current-format \;\
-    set -u window-status-format \;\
-    set -u status-left \;\
     refresh-client -S

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -137,7 +137,7 @@ run '~/.tmux/plugins/tpm/tpm'
 set-hook -g client-attached 'run-shell "~/.config/tmux/refresh-status.sh"'
 run-shell '~/.config/tmux/refresh-status.sh'
 
-# === F12 toggle for nested tmux sessions (https://bit.ly/nested-tmux) ===
+# === F12 toggle for nested tmux sessions ===
 
 # Show white-on-red "OFF" badge in status-right when key-table is 'off'
 set -ga status-right "#[fg=#f8f8f2,bg=#ff5555,bold]#([ $(tmux show-option -qv key-table) = 'off' ] && echo ' OFF ')#[default]"

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -137,34 +137,19 @@ run '~/.tmux/plugins/tpm/tpm'
 set-hook -g client-attached 'run-shell "~/.config/tmux/refresh-status.sh"'
 run-shell '~/.config/tmux/refresh-status.sh'
 
-# === Nested session support: F12 toggles this tmux "off" ===
-# When SSH/Mosh-ing from a local Mac (which runs its own tmux) into this
-# remote server (also running tmux), both sessions compete for the same
-# prefix key. F12 disables the outer (remote) tmux so all keys pass through
-# to the inner (local) session. Pressing F12 again re-enables it.
-#
-# The OFF toggle uses `set` (session-level overrides), and the ON toggle
-# uses `set -u` (unset session-level), so global values set by Dracula
-# and refresh-status.sh are never touched and restore cleanly.
-#
-# Reference: https://www.freecodecamp.org/news/tmux-in-practice-local-and-nested-remote-tmux-sessions-4f7ba5db8795/
+# === F12 toggle for nested tmux sessions (https://bit.ly/nested-tmux) ===
 
-# Append OFF indicator to status-right. The #() command substitution checks
-# the current key-table: outputs nothing in normal mode, shows white-on-red
-# "OFF" badge when key-table is 'off'.
+# Show white-on-red "OFF" badge in status-right when key-table is 'off'
 set -ga status-right "#[fg=#f8f8f2,bg=#ff5555,bold]#([ $(tmux show-option -qv key-table) = 'off' ] && echo ' OFF ')#[default]"
 
-# Toggle OFF: set prefix to None so no key combo activates tmux, and switch
-# to the 'off' key-table so all keys pass through to the inner session.
-# Also cancels copy-mode if active, since it would be unusable without prefix.
+# Toggle OFF: disable prefix and pass all keys through to inner session
 bind -T root F12 \
     set prefix None \;\
     set key-table off \;\
     if -F '#{pane_in_mode}' 'send-keys -X cancel' \;\
     refresh-client -S \;
 
-# Toggle ON: unset session-level overrides to reveal the global values
-# that Dracula and refresh-status.sh originally configured.
+# Toggle ON: unset session overrides to restore Dracula/refresh-status globals
 bind -T off F12 \
     set -u prefix \;\
     set -u key-table \;\

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -121,7 +121,7 @@ set -g @yank_action 'copy-pipe'
 set -g @dracula-show-powerline true
 set -g @dracula-plugins "cpu-usage ram-usage"
 set -g @dracula-show-flags true
-set -g @dracula-show-left-icon session
+set -g @dracula-show-left-icon "#S#{?#{==:#{client_key_table},off}, 🚫,}"
 set -g @dracula-left-icon-padding 0
 set -g @dracula-border-contrast true
 set -g status-position top
@@ -138,9 +138,6 @@ set-hook -g client-attached 'run-shell "~/.config/tmux/refresh-status.sh"'
 run-shell '~/.config/tmux/refresh-status.sh'
 
 # === F12 toggle for nested tmux sessions ===
-
-# Show white-on-red "OFF" badge in status-right when key-table is 'off'
-set -ga status-right "#[fg=#f8f8f2,bg=#ff5555,bold]#([ $(tmux show-option -qv key-table) = 'off' ] && echo ' OFF ')#[default]"
 
 # Toggle OFF: disable prefix and pass all keys through to inner session
 bind -T root F12 \


### PR DESCRIPTION
## Summary
- Add F12 key binding to toggle the remote tmux "off" so all keys pass through to the inner (local) tmux session — solves prefix key conflicts when nesting tmux over SSH/Mosh
- Status bar shows a 🚫 indicator in the left icon when toggled off; pressing F12 again unsets session-level overrides, cleanly restoring Dracula theme globals
- Add `attached-clients` and `ssh-session` Dracula plugins so the status bar always shows `user@hostname` and connected client count — easy to distinguish local from remote at a glance
- Move status bar to bottom on SSH/Mosh connections via `refresh-status.sh`, keeping it at top locally

## Visual differentiation

| Session | Status position | ssh-session widget | Prefix |
|---------|----------------|--------------------|--------|
| Local | top | `user@localmachine` | C-a |
| SSH | bottom | `user@remotehost` | C-a |
| Mosh | bottom | `user@remotehost` | C-b |

## Test plan
- [ ] `tmux source-file ~/.tmux.conf` — config reloads without errors, new plugins visible
- [ ] `tmux list-keys | grep F12` — both root and off table bindings present
- [ ] Press **F12** — 🚫 appears in left icon, prefix key stops working
- [ ] Press **F12** again — indicator clears, prefix works
- [ ] SSH to remote → `tmux` — status bar at bottom, `ssh-session` shows remote hostname
- [ ] Mosh to remote → `tmux` — status bar at bottom, prefix is `C-b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)