### PR TITLE
Dim Dracula status bar for inner (SSH) tmux sessions

### DIFF
--- a/.config/tmux/refresh-status.sh
+++ b/.config/tmux/refresh-status.sh
@@ -22,6 +22,3 @@ if $rs_is_mosh; then
     tmux bind C-b send-prefix
 fi
 
-if [ -n "$SSH_CONNECTION" ] || [ -n "$SSH_CLIENT" ]; then
-    tmux set -g status-position bottom
-fi

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -124,11 +124,17 @@ set -g @dracula-show-flags true
 set -g @dracula-show-left-icon "#S#{?#{==:#{client_key_table},off}, 🚫,}"
 set -g @dracula-left-icon-padding 0
 set -g @dracula-border-contrast true
+set -g @dracula-clients-minimum 2
 set -g status-position top
 
 # enable pane titles
 set-option -g pane-border-status top
 set-option -g pane-border-format "#{pane_index}: #{pane_title}"
+
+# Dim Dracula accent colors for inner (SSH) tmux sessions
+if-shell '[ -n "$SSH_CONNECTION" ] || [ -n "$SSH_CLIENT" ]' {
+    set -g @dracula-colors "green='#58ad6d' cyan='#75a4ae' orange='#af8c66' pink='#af6c93' yellow='#a8ad76' light_purple='#8e79ac' red='#af5a5a' purple='#886396'"
+}
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary
- Dim the Dracula theme's accent colors on inner (SSH) tmux sessions using `@dracula-colors`, replacing bright accents with desaturated variants that preserve hue distinction
- Keep the inner session's status bar at the top (default) instead of moving it to the bottom
- Hide the attached-clients widget when only one client is connected (`@dracula-clients-minimum 2`)

## Color mapping

| Color | Original | Dimmed | Used by |
|-------|----------|--------|---------|
| green | `#50fa7b` | `#58ad6d` | Left icon, ssh-session |
| cyan | `#8be9fd` | `#75a4ae` | ram-usage, attached-clients |
| orange | `#ffb86c` | `#af8c66` | cpu-usage |
| pink | `#ff79c6` | `#af6c93` | battery, GPU |
| yellow | `#f1fa8c` | `#a8ad76` | prefix indicator |
| light_purple | `#bd93f9` | `#8e79ac` | pane border |
| red | `#ff5555` | `#af5a5a` | error states |
| purple | `#b166cc` | `#886396` | player plugins |

## Test plan
- [ ] SSH into remote and start tmux — status bar should show desaturated but hue-distinct colors
- [ ] Local tmux session should remain unchanged with bright accent colors
- [ ] Inner status bar stays at top (same as outer)
- [ ] Attached-clients widget hidden with a single client, visible with 2+
- [ ] F12 toggle still works for nested session key passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)