### PR TITLE
Move tmux config to XDG path and hide plugins on narrow screens

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -39,7 +39,7 @@ set -g focus-events on
 setw -g aggressive-resize on
 
 # Reload tmux config with Prefix + r
-bind r source-file ~/.tmux.conf \; display "Reloaded tmux config"
+bind r source-file ~/.config/tmux/tmux.conf \; display "Reloaded tmux config"
 
 # select next window
 unbind n
@@ -118,7 +118,9 @@ set -g @yank_action 'copy-pipe'
 
 # configure theme
 set -g @dracula-show-powerline true
-set -g @dracula-plugins "cpu-usage ram-usage attached-clients ssh-session"
+set -g @dracula-plugins "compact-alt cpu-usage ram-usage attached-clients ssh-session"
+set -g @dracula-narrow-plugins "compact-alt"
+set -g @dracula-compact-min-width 100
 set -g @dracula-show-flags true
 set -g @dracula-show-left-icon "#S#{?#{==:#{client_key_table},off}, 🚫,}"
 set -g @dracula-left-icon-padding 0
@@ -140,7 +142,7 @@ if-shell '[ -n "$SSH_CONNECTION" ] || [ -n "$SSH_CLIENT" ]' {
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'
 
-# Adapt prefix and status bar for mosh sessions (restore: tmux source ~/.tmux.conf)
+# Adapt prefix and status bar for mosh sessions (restore: tmux source ~/.config/tmux/tmux.conf)
 set-hook -g client-attached 'run-shell "~/.config/tmux/refresh-status.sh"'
 run-shell '~/.config/tmux/refresh-status.sh'
 


### PR DESCRIPTION
## Summary
- Move `.tmux.conf` to `~/.config/tmux/tmux.conf` (XDG convention, matches Dracula default config path)
- Add Dracula `compact-alt` plugin to hide status bar widgets on screens narrower than 100 columns
- Update reload binding and comment references to new path

## Test plan
- [ ] Reload tmux config with `prefix + r`
- [ ] Verify plugins hide on narrow terminal (< 100 cols)
- [ ] Verify plugins show on wide terminal (>= 100 cols)

🤖 Generated with [Claude Code](https://claude.com/claude-code)