### PR TITLE
Enhance F12 toggle to visually recede outer tmux session

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -134,10 +134,6 @@ set -g status-position top
 set-option -g pane-border-status top
 set-option -g pane-border-format "#{pane_index}: #{pane_title}"
 
-# Dim Dracula accent colors for inner (SSH) tmux sessions
-if-shell '[ -n "$SSH_CONNECTION" ] || [ -n "$SSH_CLIENT" ]' {
-    set -g @dracula-colors "white='#A89984' gray='#32302F' dark_gray='#282828' light_purple='#B16286' dark_purple='#504945' cyan='#689D6A' green='#98971A' orange='#D65D0E' red='#CC241D' pink='#D3869B' yellow='#D79921'"
-}
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -136,7 +136,7 @@ set-option -g pane-border-format "#{pane_index}: #{pane_title}"
 
 # Dim Dracula accent colors for inner (SSH) tmux sessions
 if-shell '[ -n "$SSH_CONNECTION" ] || [ -n "$SSH_CLIENT" ]' {
-    set -g @dracula-colors "green='#58ad6d' cyan='#75a4ae' orange='#af8c66' pink='#af6c93' yellow='#a8ad76' light_purple='#8e79ac' red='#af5a5a' purple='#886396'"
+    set -g @dracula-colors "white='#A89984' gray='#32302F' dark_gray='#282828' light_purple='#B16286' dark_purple='#504945' cyan='#689D6A' green='#98971A' orange='#D65D0E' red='#CC241D' pink='#D3869B' yellow='#D79921'"
 }
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
@@ -148,15 +148,21 @@ run-shell '~/.config/tmux/refresh-status.sh'
 
 # === F12 toggle for nested tmux sessions ===
 
-# Toggle OFF: disable prefix and pass all keys through to inner session
+# Toggle OFF: disable prefix, dim outer status bar, pass all keys to inner session
 bind -T root F12 \
     set prefix None \;\
     set key-table off \;\
+    set -g @dracula-colors "white='#A89984' gray='#32302F' dark_gray='#282828' light_purple='#B16286' dark_purple='#504945' cyan='#689D6A' green='#98971A' orange='#D65D0E' red='#CC241D' pink='#D3869B' yellow='#D79921'" \;\
+    set -g status-position bottom \;\
+    set -g pane-border-status off \;\
     if -F '#{pane_in_mode}' 'send-keys -X cancel' \;\
-    refresh-client -S \;
+    run 'tmux source-file ~/.config/tmux/tmux.conf'
 
 # Toggle ON: unset session overrides to restore Dracula/refresh-status globals
 bind -T off F12 \
     set -u prefix \;\
     set -u key-table \;\
-    refresh-client -S
+    set -g @dracula-colors "" \;\
+    set -g status-position top \;\
+    set -g pane-border-status top \;\
+    run 'tmux source-file ~/.config/tmux/tmux.conf'


### PR DESCRIPTION
## Summary

- Replace hand-rolled dimmed Dracula colors with the Gruvbox muted palette (from Dracula's built-in theme presets) for the F12 nested-session toggle
- F12 toggle-OFF now also moves the status bar to the bottom and hides pane borders, so the outer session visually recedes
- F12 toggle-ON restores status bar position (top), pane border titles (top), and default Dracula colors
- Both toggles re-source the config to force Dracula to redraw with the updated palette
- Remove the automatic SSH color dimming — all visual changes are now controlled exclusively by F12

## Test plan

- [ ] `prefix + r` to reload config
- [ ] Open a nested tmux session over SSH — outer session should look normal (no auto-dimming)
- [ ] Press F12 — outer status bar should switch to Gruvbox muted colors, move to the bottom, and hide pane border titles
- [ ] Press F12 again — outer session should fully restore (colors, status bar top, pane borders top)
- [ ] Verify the 🚫 indicator still appears in the left icon when toggled off

🤖 Generated with [Claude Code](https://claude.com/claude-code)