### PR TITLE
Fix F12 nested session toggle overriding its own settings

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -152,7 +152,7 @@ bind -T root F12 \
     set -g status-position bottom \;\
     set -g pane-border-status off \;\
     if -F '#{pane_in_mode}' 'send-keys -X cancel' \;\
-    run 'tmux source-file ~/.config/tmux/tmux.conf'
+    run '~/.tmux/plugins/tmux/scripts/dracula.sh'
 
 # Toggle ON: unset session overrides to restore Dracula/refresh-status globals
 bind -T off F12 \
@@ -161,4 +161,4 @@ bind -T off F12 \
     set -g @dracula-colors "" \;\
     set -g status-position top \;\
     set -g pane-border-status top \;\
-    run 'tmux source-file ~/.config/tmux/tmux.conf'
+    run '~/.tmux/plugins/tmux/scripts/dracula.sh'


### PR DESCRIPTION
## Summary
- Re-sourcing the full tmux config from the F12 toggle was overriding `status-position` and `pane-border-status` that the toggle had just set, since those values are hardcoded in the config body
- Fix: run the Dracula theme script directly (`dracula.sh`) instead of re-sourcing the entire config, so only the color palette is re-rendered without clobbering the other toggle settings

## Test plan
- [ ] Press F12 — status bar should move to bottom, pane borders should hide, colors should become muted
- [ ] Press F12 again — status bar should return to top, pane borders should reappear, colors should restore to default Dracula

🤖 Generated with [Claude Code](https://claude.com/claude-code)