### PR TITLE
Fix Dracula theme not loading after XDG config migration

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -135,6 +135,9 @@ set-option -g pane-border-status top
 set-option -g pane-border-format "#{pane_index}: #{pane_title}"
 
 
+# Tell TPM where plugins are installed (overrides XDG default of ~/.config/tmux/plugins/)
+set-environment -g TMUX_PLUGIN_MANAGER_PATH "$HOME/.tmux/plugins/"
+
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'
 


### PR DESCRIPTION
## Summary
- TPM auto-detects `~/.config/tmux/tmux.conf` and sets the plugin path to `~/.config/tmux/plugins/`, but plugins are installed at `~/.tmux/plugins/`
- This caused TPM to silently skip sourcing all plugins, leaving the default green tmux status bar instead of the Dracula theme
- Fix: explicitly set `TMUX_PLUGIN_MANAGER_PATH` before TPM initialization to point to the correct plugin directory

## Test plan
- [ ] Restart tmux and verify Dracula theme loads automatically (no green status bar)
- [ ] Verify `tmux show-environment -g TMUX_PLUGIN_MANAGER_PATH` returns `~/.tmux/plugins/`
- [ ] Verify other TPM plugins (tmux-resurrect, tmux-yank, vim-tmux-navigator) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)