### PR TITLE
Move tmux plugins to XDG-compliant directory

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -145,7 +145,7 @@ set-option -g pane-border-status top
 set-option -g pane-border-format "#{pane_index}: #{pane_title}"
 
 
-# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
+# Initialize TMUX plugin manager (must be after all @plugin declarations)
 run '~/.config/tmux/plugins/tpm/tpm'
 
 # Adapt prefix and status bar for mosh sessions (restore: tmux source ~/.config/tmux/tmux.conf)

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -112,9 +112,19 @@ set -g @plugin 'dracula/tmux'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'christoomey/vim-tmux-navigator'
+set -g @plugin 'roosta/tmux-fuzzback'
+set -g @plugin 'laktak/extrakto'
 
 # tmux-yank: stay in copy mode after yanking (matches previous copy-pipe behavior)
 set -g @yank_action 'copy-pipe'
+
+# tmux-fuzzback: fuzzy search scrollback buffer (prefix + ?)
+set -g @fuzzback-popup 1
+set -g @fuzzback-popup-size '90%'
+
+# extrakto: extract tokens from scrollback (prefix + tab)
+set -g @extrakto_split_direction 'p'
+set -g @extrakto_popup_size '90%'
 
 # configure theme
 set -g @dracula-show-powerline true
@@ -135,11 +145,8 @@ set-option -g pane-border-status top
 set-option -g pane-border-format "#{pane_index}: #{pane_title}"
 
 
-# Tell TPM where plugins are installed (overrides XDG default of ~/.config/tmux/plugins/)
-set-environment -g TMUX_PLUGIN_MANAGER_PATH "$HOME/.tmux/plugins/"
-
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
-run '~/.tmux/plugins/tpm/tpm'
+run '~/.config/tmux/plugins/tpm/tpm'
 
 # Adapt prefix and status bar for mosh sessions (restore: tmux source ~/.config/tmux/tmux.conf)
 set-hook -g client-attached 'run-shell "~/.config/tmux/refresh-status.sh"'
@@ -155,7 +162,7 @@ bind -T root F12 \
     set -g status-position bottom \;\
     set -g pane-border-status off \;\
     if -F '#{pane_in_mode}' 'send-keys -X cancel' \;\
-    run '~/.tmux/plugins/tmux/scripts/dracula.sh'
+    run '~/.config/tmux/plugins/tmux/scripts/dracula.sh'
 
 # Toggle ON: unset session overrides to restore Dracula/refresh-status globals
 bind -T off F12 \
@@ -164,4 +171,4 @@ bind -T off F12 \
     set -g @dracula-colors "" \;\
     set -g status-position top \;\
     set -g pane-border-status top \;\
-    run '~/.tmux/plugins/tmux/scripts/dracula.sh'
+    run '~/.config/tmux/plugins/tmux/scripts/dracula.sh'

--- a/.config/yadm/bootstrap##distro.Ubuntu
+++ b/.config/yadm/bootstrap##distro.Ubuntu
@@ -101,10 +101,10 @@ command -v luarocks &>/dev/null && echo "Installing/updating luarocks completion
 command -v mise &>/dev/null && echo "Installing/updating mise completion..." && mise completion zsh >"${completions_dir}/_mise"
 
 # install tmux plugin manager
-if [ ! -d "${HOME}/.tmux/plugins/tpm" ]; then
+if [ ! -d "${HOME}/.config/tmux/plugins/tpm" ]; then
     echo "Installing tmux plugin manager..."
-    mkdir -p "${HOME}/.tmux/plugins"
-    git clone https://github.com/tmux-plugins/tpm "${HOME}/.tmux/plugins/tpm"
+    mkdir -p "${HOME}/.config/tmux/plugins"
+    git clone https://github.com/tmux-plugins/tpm "${HOME}/.config/tmux/plugins/tpm"
 else
     echo "tmux plugin manager is already installed. Skipping..."
 fi

--- a/.config/yadm/bootstrap##os.Darwin
+++ b/.config/yadm/bootstrap##os.Darwin
@@ -76,10 +76,10 @@ command -v luarocks &>/dev/null && echo "Installing/updating luarocks completion
 command -v mise &>/dev/null && echo "Installing/updating mise completion..." && mise completion zsh >"${completions_dir}/_mise"
 
 # install tmux plugin manager
-if [ ! -d "${HOME}/.tmux/plugins/tpm" ]; then
+if [ ! -d "${HOME}/.config/tmux/plugins/tpm" ]; then
     echo "Installing tmux plugin manager..."
-    mkdir -p "${HOME}/.tmux/plugins"
-    git clone https://github.com/tmux-plugins/tpm "${HOME}/.tmux/plugins/tpm"
+    mkdir -p "${HOME}/.config/tmux/plugins"
+    git clone https://github.com/tmux-plugins/tpm "${HOME}/.config/tmux/plugins/tpm"
 fi
 
 # update tldr cache


### PR DESCRIPTION
## Summary
- Remove `TMUX_PLUGIN_MANAGER_PATH` override from tmux.conf — TPM auto-detects `~/.config/tmux/plugins/` when config is at `~/.config/tmux/tmux.conf`
- Update all plugin paths from `~/.tmux/plugins/` to `~/.config/tmux/plugins/` in tmux.conf, Ubuntu bootstrap, and macOS bootstrap
- Completes the XDG migration started in #61 and removes the workaround from #64

## Manual steps (per machine, after merge)
```bash
mv ~/.tmux/plugins ~/.config/tmux/plugins
rmdir ~/.tmux 2>/dev/null
# prefix + r  (reload config)
# prefix + I  (verify plugins)
```

## Test plan
- [ ] Reload config with `prefix + r` — no errors
- [ ] `prefix + I` — TPM reports all plugins already installed
- [ ] Dracula theme loads (status bar at top, not green default)
- [ ] `F12` toggle works (Dracula re-renders with muted/normal colors)
- [ ] Plugins functional: fuzzback (`prefix + ?`), extrakto (`prefix + tab`), resurrect, yank, vim-navigator

🤖 Generated with [Claude Code](https://claude.com/claude-code)