### PR TITLE
Remove nvim-notify plugin to fix conflict with noice.nvim

### DIFF
--- a/.config/lazyvim/lua/plugins/notify.lua
+++ b/.config/lazyvim/lua/plugins/notify.lua
@@ -1,8 +1,0 @@
-return {
-  "rcarriga/nvim-notify",
-  opts = {
-    level = 3,
-    render = "minimal",
-    stages = "static",
-  },
-}


### PR DESCRIPTION
## Summary
- Remove standalone `nvim-notify` plugin config that conflicted with LazyVim's built-in `noice.nvim`
- Fixes "vim.notify has been overwritten by another plugin" error on startup

## Test plan
- [ ] Open `lvim` and confirm no notification error on startup
- [ ] Verify notifications still work (e.g., `:Lazy update` progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)