### PR TITLE
Add mise status settings

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,6 +1,10 @@
 [settings]
 idiomatic_version_file_enable_tools = ["node", "ruby"]
 
+[settings.status]
+show_tools = true
+show_env = true
+
 [tools]
 go = "1.22.2"
 node = "22.22.0"


### PR DESCRIPTION
## Summary
- Enable `show_tools` and `show_env` in mise status settings for better visibility into active tools and environment variables

## Test plan
- [ ] Run `mise status` and verify tools and env info are displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)