### PR TITLE
Add tmux-sessionx and tmuxinator for session management

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -5,6 +5,7 @@ idiomatic_version_file_enable_tools = ["node", "ruby"]
 go = "1.22.2"
 node = "22.22.0"
 python = "3.13.12"
+ruby = "latest"
 shfmt = "latest"
 yamlfmt = "latest"
 

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -132,7 +132,11 @@ set -g @sessionx-bind 'o'
 set -g @sessionx-zoxide-mode 'on'
 set -g @sessionx-tmuxinator-mode 'on'
 set -g @sessionx-preview-location 'right'
-set -g @sessionx-preview-ratio '55%'
+set -g @sessionx-preview-ratio '45%'
+set -g @sessionx-filter-current 'false'
+set -g @sessionx-git-branch 'on'
+set -g @sessionx-tree-mode 'off'
+set -g @sessionx-window-mode 'off'
 
 # configure theme
 set -g @dracula-show-powerline true

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -137,6 +137,7 @@ set -g @sessionx-filter-current 'false'
 set -g @sessionx-git-branch 'on'
 set -g @sessionx-tree-mode 'off'
 set -g @sessionx-window-mode 'off'
+set -g @sessionx-bind-kill-session 'alt-x'
 
 # configure theme
 set -g @dracula-show-powerline true

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -114,6 +114,7 @@ set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'christoomey/vim-tmux-navigator'
 set -g @plugin 'roosta/tmux-fuzzback'
 set -g @plugin 'laktak/extrakto'
+set -g @plugin 'omerxx/tmux-sessionx'
 
 # tmux-yank: stay in copy mode after yanking (matches previous copy-pipe behavior)
 set -g @yank_action 'copy-pipe'
@@ -125,6 +126,13 @@ set -g @fuzzback-popup-size '90%'
 # extrakto: extract tokens from scrollback (prefix + tab)
 set -g @extrakto_split_direction 'p'
 set -g @extrakto_popup_size '90%'
+
+# sessionx: session manager (prefix + O)
+set -g @sessionx-bind 'o'
+set -g @sessionx-zoxide-mode 'on'
+set -g @sessionx-tmuxinator-mode 'on'
+set -g @sessionx-preview-location 'right'
+set -g @sessionx-preview-ratio '55%'
 
 # configure theme
 set -g @dracula-show-powerline true

--- a/.config/tmuxinator/raider.yml
+++ b/.config/tmuxinator/raider.yml
@@ -1,0 +1,7 @@
+name: <%= File.basename(@args[0]) %>
+root: <%= @args[0] %>
+
+windows:
+  - claude:
+  - editor: nvim
+  - shell:

--- a/.config/tmuxinator/raider.yml
+++ b/.config/tmuxinator/raider.yml
@@ -1,7 +1,0 @@
-name: <%= File.basename(@args[0]) %>
-root: <%= @args[0] %>
-
-windows:
-  - claude:
-  - editor: nvim
-  - shell:

--- a/.config/yadm/bootstrap##distro.Ubuntu
+++ b/.config/yadm/bootstrap##distro.Ubuntu
@@ -74,6 +74,11 @@ eval "$(~/.local/bin/mise activate bash --shims)"
 mise install
 mise prune --yes
 
+# install tmuxinator — use mise-managed gem directly because mise's gem: backend
+# may resolve to system Ruby instead of mise-managed Ruby
+echo "Installing/updating tmuxinator..."
+"$(mise which gem)" install tmuxinator
+
 # install rust and cargo
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 
@@ -99,6 +104,7 @@ command -v uvx &>/dev/null && echo "Installing/updating uvx completion..." && uv
 command -v poetry &>/dev/null && echo "Installing/updating poetry completion..." && poetry completions zsh >"${completions_dir}/_poetry"
 command -v luarocks &>/dev/null && echo "Installing/updating luarocks completion..." && luarocks completion zsh >"${completions_dir}/_luarocks"
 command -v mise &>/dev/null && echo "Installing/updating mise completion..." && mise completion zsh >"${completions_dir}/_mise"
+command -v tmuxinator &>/dev/null && echo "Installing/updating tmuxinator completion..." && curl --location --silent https://raw.githubusercontent.com/tmuxinator/tmuxinator/master/completion/tmuxinator.zsh --output "${completions_dir}/_tmuxinator"
 
 # install tmux plugin manager
 if [ ! -d "${HOME}/.config/tmux/plugins/tpm" ]; then

--- a/.config/yadm/bootstrap##os.Darwin
+++ b/.config/yadm/bootstrap##os.Darwin
@@ -58,6 +58,11 @@ eval "$(mise activate bash --shims)"
 mise install
 mise prune --yes
 
+# install tmuxinator — use mise-managed gem directly because mise's gem: backend
+# resolves to macOS system Ruby (/usr/bin/ruby 2.6) instead of mise-managed Ruby
+echo "Installing/updating tmuxinator..."
+"$(mise which gem)" install tmuxinator
+
 # update completions
 completions_dir="${HOME}/.config/zsh/completions"
 mkdir -p "${completions_dir}"
@@ -74,6 +79,7 @@ command -v uvx &>/dev/null && echo "Installing/updating uvx completion..." && uv
 command -v poetry &>/dev/null && echo "Installing/updating poetry completion..." && poetry completions zsh >"${completions_dir}/_poetry"
 command -v luarocks &>/dev/null && echo "Installing/updating luarocks completion..." && luarocks completion zsh >"${completions_dir}/_luarocks"
 command -v mise &>/dev/null && echo "Installing/updating mise completion..." && mise completion zsh >"${completions_dir}/_mise"
+command -v tmuxinator &>/dev/null && echo "Installing/updating tmuxinator completion..." && curl --location --silent https://raw.githubusercontent.com/tmuxinator/tmuxinator/master/completion/tmuxinator.zsh --output "${completions_dir}/_tmuxinator"
 
 # install tmux plugin manager
 if [ ! -d "${HOME}/.config/tmux/plugins/tpm" ]; then

--- a/.github/README.md
+++ b/.github/README.md
@@ -37,7 +37,9 @@ more easily managed with version control systems.
 
 ### 💻 Tmux
 
-Tmux plugins installed via [TPM](https://github.com/tmux-plugins/tpm):
+Tmux plugins installed via [TPM](https://github.com/tmux-plugins/tpm), plus
+[tmuxinator](https://github.com/tmuxinator/tmuxinator) as a companion tool for
+session layouts:
 
 | Plugin | Description |
 | ------ | ----------- |
@@ -47,6 +49,8 @@ Tmux plugins installed via [TPM](https://github.com/tmux-plugins/tpm):
 | [vim-tmux-navigator](https://github.com/christoomey/vim-tmux-navigator) | Seamless navigation between tmux panes and Vim splits |
 | [tmux-fuzzback](https://github.com/roosta/tmux-fuzzback) | Fuzzy search scrollback buffer via fzf popup |
 | [extrakto](https://github.com/laktak/extrakto) | Extract and select tokens (URLs, paths, hashes) from scrollback |
+| [tmux-sessionx](https://github.com/omerxx/tmux-sessionx) | Fuzzy session picker with zoxide and tmuxinator integration |
+| [tmuxinator](https://github.com/tmuxinator/tmuxinator) | Define and manage tmux session layouts via YAML |
 
 The status bar is positioned at the top. When connecting via
 [mosh](https://mosh.org/), the prefix automatically switches back to `C-b` so it
@@ -92,6 +96,7 @@ The `<Prefix>` Keybinding has been remapped to `C-a`, replacing the default
 | `<Prefix> (`              | Goto previous session                                    |
 | `<Prefix> ?`              | Fuzzy search scrollback buffer (tmux-fuzzback)           |
 | `<Prefix> Tab`            | Extract and select tokens from scrollback (extrakto)     |
+| `<Prefix> O`              | Fuzzy session picker with zoxide integration (sessionx)  |
 
 ##### Updating Configuration and Managing Plugins
 
@@ -296,6 +301,7 @@ Below is a list of CLI utilities that are installed.
 | `macos-trash` | A command-line interface to the macOS trash (e.g, `trash file.txt`). | [Link](https://github.com/sindresorhus/macos-trash) |
 | `ripgrep`   | A fast line-oriented search tool, like `grep` with steroids.         | [Link](https://github.com/BurntSushi/ripgrep)       |
 | `tealdeer`  | More readable `man` pages (e.g., `tldr grep`)                        | [Link](https://github.com/dbrgn/tealdeer)           |
+| `tmuxinator` | Define and manage tmux session layouts via YAML.                     | [Link](https://github.com/tmuxinator/tmuxinator)    |
 | `tree`      | A recursive directory listing command with tree-like output.         | [Link](http://mama.indstate.edu/users/ice/tree)     |
 | `eza`       | Modern replacement for `ls`.                                         | [Link](https://github.com/eza-community/eza)        |
 | `zoxide`    | A smarter `cd` command.                                              | [Link](https://github.com/ajeetdsouza/zoxide)       |

--- a/.ubuntu-packages##distro.Ubuntu
+++ b/.ubuntu-packages##distro.Ubuntu
@@ -1,4 +1,5 @@
 apt-transport-https
+bat
 build-essential
 bzip2
 ca-certificates


### PR DESCRIPTION
## Summary
- Add **tmux-sessionx** TPM plugin with zoxide and tmuxinator integration (bound to `prefix + O`)
- Add **tmuxinator** installed via mise-managed Ruby's gem (workaround: mise's `gem:` backend resolves to system Ruby instead of mise-managed Ruby)
- Add Ruby to mise global config
- Add `bat` to Ubuntu packages (sessionx preview dependency)
- Add tmuxinator zsh completion to both Darwin and Ubuntu bootstrap scripts

## Test plan
- [x] `yadm bootstrap` completes successfully (tmuxinator installs via `$(mise which gem)`)
- [ ] `prefix + I` installs sessionx TPM plugin
- [ ] `prefix + O` opens sessionx session picker
- [ ] `tmuxinator doctor` reports healthy config

🤖 Generated with [Claude Code](https://claude.com/claude-code)