### PR TITLE
Add libyaml-dev to Ubuntu packages for Ruby

### DIFF
--- a/.ubuntu-packages##distro.Ubuntu
+++ b/.ubuntu-packages##distro.Ubuntu
@@ -24,6 +24,7 @@ libbz2-dev
 libffi-dev
 libglib2.0-0
 liblzma-dev
+libyaml-dev
 libncursesw5-dev
 libpq-dev
 libreadline-dev


### PR DESCRIPTION
## Summary
- Adds `libyaml-dev` to Ubuntu package list as a Ruby build dependency

## Test plan
- [ ] Verify `libyaml-dev` installs correctly via bootstrap script

🤖 Generated with [Claude Code](https://claude.com/claude-code)