### PR TITLE
Add bun to mise-managed tools

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -5,6 +5,7 @@ idiomatic_version_file_enable_tools = ["node", "ruby"]
 go = "1.22.2"
 node = "22.22.0"
 python = "3.13.12"
+bun = "latest"
 ruby = "latest"
 shfmt = "latest"
 yamlfmt = "latest"


### PR DESCRIPTION
## Summary
- Removes manual bun installation (curl script) in favor of mise
- Adds `bun = "latest"` to `~/.config/mise/config.toml` alongside other runtimes

## Test plan
- [ ] Run `yadm bootstrap` to install bun via mise
- [ ] Verify `mise which bun` resolves correctly
- [ ] Verify `bun --version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)