### PR TITLE
Enable tmux window renumbering

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -157,6 +157,8 @@ set -g status-position top
 set-option -g pane-border-status top
 set-option -g pane-border-format "#{pane_index}: #{pane_title}"
 
+# auto renumber
+set -g renumber-windows on
 
 # Initialize TMUX plugin manager (must be after all @plugin declarations)
 run '~/.config/tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary
- Add `renumber-windows on` to tmux config so window indices stay sequential when a window is closed

## Test plan
- [ ] Run `tmux source ~/.config/tmux/tmux.conf` or restart tmux
- [ ] Open multiple windows, close one in the middle, and verify remaining windows are renumbered

🤖 Generated with [Claude Code](https://claude.com/claude-code)