### PR TITLE
Show prefix indicator in mobile mode

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -194,4 +194,4 @@ bind -T off F12 \
 # === prefix + m: toggle mobile mode (C-b prefix, no indicators, 📱 badge) ===
 bind m if -F '#{@mobile_mode}' \
     'source-file ~/.config/tmux/tmux.conf' \
-    'set -g @mobile_mode 1 ; set -g prefix C-b ; unbind C-a ; bind C-b send-prefix ; set -g status-left " 📱 " ; set -g status-right ""'
+    'set -g @mobile_mode 1 ; set -g prefix C-b ; unbind C-a ; bind C-b send-prefix ; set -g status-left " 📱 " ; set -g status-right "#{?client_prefix,#[fg=#{@thm_peach}] ⚡#[default],}"'


### PR DESCRIPTION
## Summary
- Keep the ⚡ prefix-active indicator visible in mobile mode instead of clearing status-right entirely

## Test plan
- [ ] Reload tmux config (`prefix + r`)
- [ ] Toggle mobile mode (`prefix + m`) and verify 📱 badge appears
- [ ] Press prefix key in mobile mode and verify ⚡ flashes on the right
- [ ] Toggle mobile mode off and verify full status bar restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)