### PR TITLE
Fix TPM double-processing all plugins during update

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -186,10 +186,13 @@ bind -T root F12 \
     if -F '#{pane_in_mode}' 'send-keys -X cancel'
 
 # Toggle ON: restore Catppuccin theme by re-sourcing config
+# NOTE: source-file must stay on the same line as the previous command.
+# TPM's _sourced_files() uses a sed regex that matches any line starting with
+# "source-file". If it's on its own line, TPM reads tmux.conf twice, causing
+# every plugin to be updated in duplicate (racing git pulls → errors).
 bind -T off F12 \
     set -u prefix \;\
-    set -u key-table \;\
-    source-file ~/.config/tmux/tmux.conf
+    set -u key-table \; source-file ~/.config/tmux/tmux.conf
 
 # === prefix + m: toggle mobile mode (C-b prefix, no indicators, 📱 badge) ===
 bind m if -F '#{@mobile_mode}' \


### PR DESCRIPTION
## Summary
- TPM's `_sourced_files()` regex was matching a `source-file` directive inside a multi-line `bind` command, causing tmux.conf to be read twice
- Every plugin was listed twice, triggering two parallel `git pull` operations per plugin that raced each other and produced errors
- Fixed by joining the `source-file` onto the same line as the previous command so it no longer matches TPM's regex

## Test plan
- [x] Reload tmux config with `Prefix + r`
- [x] Run `Prefix + U` → `all` and confirm each plugin appears once with no errors
- [x] Toggle F12 off/on and confirm Catppuccin theme restores correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)