### PR TITLE
Slim README by moving detailed tables into sub-pages

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -23,10 +23,8 @@ yadm bootstrap
 
 ## Stack
 
-| Tool                                                               | Details                      |
-| ------------------------------------------------------------------ | ---------------------------- |
-| [Alacritty](https://github.com/alacritty/alacritty)                | [Details](docs/alacritty.md) |
-| [Zsh](https://www.zsh.org/)                                        | [Details](docs/shell.md)     |
-| [Tmux](https://github.com/tmux/tmux)                               | [Details](docs/tmux.md)      |
-| [Neovim](https://neovim.io) / [LazyVim](https://www.lazyvim.org/)  | [Details](docs/neovim.md)    |
-| [IdeaVim](https://github.com/JetBrains/ideavim)                    | [Details](docs/ideavim.md)   |
+- 🖥️ **[Alacritty](https://github.com/alacritty/alacritty)** — Terminal emulator · [Details](docs/alacritty.md)
+- 🐚 **[Zsh](https://www.zsh.org/)** — Shell with antidote and Starship · [Details](docs/shell.md)
+- 💻 **[Tmux](https://github.com/tmux/tmux)** — Terminal multiplexer · [Details](docs/tmux.md)
+- 🚀 **[Neovim](https://neovim.io)** — Terminal editor via LazyVim · [Details](docs/neovim.md)
+- 🔧 **[IdeaVim](https://github.com/JetBrains/ideavim)** — Vim emulation in JetBrains · [Details](docs/ideavim.md)

--- a/.github/README.md
+++ b/.github/README.md
@@ -37,8 +37,8 @@ plugin manager and [Starship](https://starship.rs/) as the prompt.
 
 ## Tmux
 
-[Tmux](https://github.com/tmux/tmux) prefix is remapped to `C-a`. A ⚡ indicator
-appears in the status bar when the prefix key is active. Use `<Prefix> m` to
+[Tmux](https://github.com/tmux/tmux) prefix is remapped to `C-a`. The status bar
+shows the ⚡ symbol when the prefix key is active. Use `<Prefix> m` to
 toggle mobile mode, which switches the prefix to `C-b`, hides status indicators,
 and shows a 📱 badge.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -23,7 +23,7 @@ yadm bootstrap
 
 ## Stack
 
-Core tools configured in these dotfiles.
+Core tools configured in these dotfiles:
 
 - 🖥️ **[Alacritty](docs/alacritty.md)** - Terminal emulator
 - 🐚 **[Zsh](docs/shell.md)** - Shell with antidote and Starship

--- a/.github/README.md
+++ b/.github/README.md
@@ -23,8 +23,8 @@ yadm bootstrap
 
 ## Stack
 
-- 🖥️ **[Alacritty](https://github.com/alacritty/alacritty)** — Terminal emulator · [Details](docs/alacritty.md)
-- 🐚 **[Zsh](https://www.zsh.org/)** — Shell with antidote and Starship · [Details](docs/shell.md)
-- 💻 **[Tmux](https://github.com/tmux/tmux)** — Terminal multiplexer · [Details](docs/tmux.md)
-- 🚀 **[Neovim](https://neovim.io)** — Terminal editor via LazyVim · [Details](docs/neovim.md)
-- 🔧 **[IdeaVim](https://github.com/JetBrains/ideavim)** — Vim emulation in JetBrains · [Details](docs/ideavim.md)
+- 🖥️ **[Alacritty](https://github.com/alacritty/alacritty)** - Terminal emulator → [docs: keymaps](docs/alacritty.md)
+- 🐚 **[Zsh](https://www.zsh.org/)** - Shell with antidote and Starship → [docs: plugins, aliases & tools](docs/shell.md)
+- 💻 **[Tmux](https://github.com/tmux/tmux)** - Terminal multiplexer → [docs: plugins & keymaps](docs/tmux.md)
+- 🚀 **[Neovim](https://neovim.io)** - Terminal editor via LazyVim → [docs: keymaps](docs/neovim.md)
+- 🔧 **[IdeaVim](https://github.com/JetBrains/ideavim)** - Vim emulation in JetBrains → [docs: plugins & keymaps](docs/ideavim.md)

--- a/.github/README.md
+++ b/.github/README.md
@@ -23,6 +23,8 @@ yadm bootstrap
 
 ## Stack
 
+Core tools configured in these dotfiles.
+
 - 🖥️ **[Alacritty](docs/alacritty.md)** - Terminal emulator
 - 🐚 **[Zsh](docs/shell.md)** - Shell with antidote and Starship
 - 💻 **[Tmux](docs/tmux.md)** - Terminal multiplexer

--- a/.github/README.md
+++ b/.github/README.md
@@ -33,149 +33,29 @@ emulator.
 Zsh is configured with [antidote](https://github.com/mattmc3/antidote) as the
 plugin manager and [Starship](https://starship.rs/) as the prompt.
 
-### Zsh Plugins
-
-| Plugin                                                                          | Description                          |
-| ------------------------------------------------------------------------------- | ------------------------------------ |
-| [zsh-completions](https://github.com/zsh-users/zsh-completions)                | Additional completion definitions    |
-| [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions)         | Fish-like autosuggestions            |
-| [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) | Syntax highlighting at the prompt    |
-| [zsh-vim-mode](https://github.com/softmoth/zsh-vim-mode)                       | Vim keybindings for the command line |
-
-### Tool Integrations
-
-| Tool                                            | Description                             |
-| ----------------------------------------------- | --------------------------------------- |
-| [fzf](https://github.com/junegunn/fzf)          | Fuzzy finder (`C-r` for history search) |
-| [zoxide](https://github.com/ajeetdsouza/zoxide) | Smarter `cd` (aliased to `cd`)          |
-| [mise](https://github.com/jdx/mise)             | Runtime version management              |
-| [Starship](https://starship.rs/)                | Cross-shell prompt                      |
-
-### Key Aliases
-
-| Alias | Expands To                                                  |
-| ----- | ----------------------------------------------------------- |
-| `v`   | `nvim`                                                      |
-| `lg`  | `lazygit`                                                   |
-| `ly`  | `lazyyadm` (lazygit for yadm files)                         |
-| `ls`  | `eza`                                                       |
-| `ll`  | `eza -la --header --git --icons --changed --time-style=iso` |
-| `cat` | `bat` (interactive terminals only)                          |
-| `cd`  | `z` (zoxide, interactive terminals only)                    |
-| `f`   | `open -a Finder ./` (macOS only)                            |
-
-### CLI Utilities
-
-Below is a list of CLI utilities that are installed.
-
-| Utility       | Description                                                          | Link                                                |
-| ------------- | -------------------------------------------------------------------- | --------------------------------------------------- |
-| `mise`        | Runtime version management (replaces pyenv/rbenv/nvm).               | [Link](https://github.com/jdx/mise)                 |
-| `uv`          | Python package and project manager.                                  | [Link](https://github.com/astral-sh/uv)             |
-| `starship`    | Cross-shell prompt.                                                  | [Link](https://starship.rs/)                        |
-| `bat`         | A `cat` clone with syntax highlighting and Git integration.          | [Link](https://github.com/sharkdp/bat)              |
-| `fd`          | A simple, fast, and user-friendly alternative to `find`.             | [Link](https://github.com/sharkdp/fd)               |
-| `fzf`         | A general-purpose command-line fuzzy finder.                         | [Link](https://github.com/junegunn/fzf)             |
-| `gh`          | GitHub's official CLI tool for managing repositories.                | [Link](https://cli.github.com)                      |
-| `git-delta`   | A viewer for git and diff output with syntax highlighting.           | [Link](https://github.com/dandavison/delta)         |
-| `lazygit`     | A simple terminal UI for git commands.                               | [Link](https://github.com/jesseduffield/lazygit)    |
-| `jq`          | A lightweight and flexible command-line JSON processor.              | [Link](https://github.com/stedolan/jq)              |
-| `macos-trash` | A command-line interface to the macOS trash (e.g, `trash file.txt`). | [Link](https://github.com/sindresorhus/macos-trash) |
-| `ripgrep`     | A fast line-oriented search tool, like `grep` with steroids.         | [Link](https://github.com/BurntSushi/ripgrep)       |
-| `tealdeer`    | More readable `man` pages (e.g., `tldr grep`)                        | [Link](https://github.com/dbrgn/tealdeer)           |
-| `tmuxinator`  | Define and manage tmux session layouts via YAML.                     | [Link](https://github.com/tmuxinator/tmuxinator)    |
-| `tree`        | A recursive directory listing command with tree-like output.         | [Link](http://mama.indstate.edu/users/ice/tree)     |
-| `eza`         | Modern replacement for `ls`.                                         | [Link](https://github.com/eza-community/eza)        |
-| `zoxide`      | A smarter `cd` command.                                              | [Link](https://github.com/ajeetdsouza/zoxide)       |
+> **[Shell Details →](docs/shell.md)**
 
 ## Tmux
 
-[Tmux](https://github.com/tmux/tmux) is the terminal multiplexer. The prefix is
-remapped to `C-a`. A ⚡ indicator appears in the status bar when the prefix key
-is active. Use `<Prefix> m` to toggle mobile mode, which switches the prefix to
-`C-b`, hides status indicators, and shows a 📱 badge.
+[Tmux](https://github.com/tmux/tmux) prefix is remapped to `C-a`. A ⚡ indicator
+appears in the status bar when the prefix key is active. Use `<Prefix> m` to
+toggle mobile mode, which switches the prefix to `C-b`, hides status indicators,
+and shows a 📱 badge.
 
-> **[Tmux Keymaps →](docs/tmux.md)**
-
-### Tmux Plugins
-
-Tmux plugins installed via [TPM](https://github.com/tmux-plugins/tpm), plus
-[tmuxinator](https://github.com/tmuxinator/tmuxinator) as a companion tool for
-session layouts:
-
-| Plugin                                                                  | Description                                                     |
-| ----------------------------------------------------------------------- | --------------------------------------------------------------- |
-| [catppuccin/tmux](https://github.com/catppuccin/tmux)                    | Status bar theme (Mocha flavor)                                 |
-| [tmux-cpu](https://github.com/tmux-plugins/tmux-cpu)                    | CPU usage indicator in status bar                               |
-| [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect)        | Save and restore tmux sessions across restarts                  |
-| [tmux-yank](https://github.com/tmux-plugins/tmux-yank)                  | Copy to system clipboard from tmux copy mode                    |
-| [vim-tmux-navigator](https://github.com/christoomey/vim-tmux-navigator) | Seamless navigation between tmux panes and Vim splits           |
-| [tmux-fuzzback](https://github.com/roosta/tmux-fuzzback)                | Fuzzy search scrollback buffer via fzf popup                    |
-| [extrakto](https://github.com/laktak/extrakto)                          | Extract and select tokens (URLs, paths, hashes) from scrollback |
-| [tmux-sessionx](https://github.com/omerxx/tmux-sessionx)                | Fuzzy session picker with zoxide and tmuxinator integration     |
-| [tmuxinator](https://github.com/tmuxinator/tmuxinator)                  | Define and manage tmux session layouts via YAML                 |
+> **[Tmux Details →](docs/tmux.md)**
 
 ## Neovim (LazyVim)
 
 [Neovim](https://neovim.io) is configured using
 [LazyVim](https://github.com/LazyVim/LazyVim) as the base distribution. See the
 [LazyVim keymaps reference](https://www.lazyvim.org/keymaps) for all default
-keybindings. Only custom overrides and additions are documented below.
-
-The `<Leader>` key is `Space`.
+keybindings. The `<Leader>` key is `Space`.
 
 > **[Neovim Keymaps →](docs/neovim.md)**
-
-### Enabled LazyVim Extras
-
-| Category   | Extra              | Full Key                 |
-| ---------- | ------------------ | ------------------------ |
-| AI         | `copilot`          | `ai.copilot`             |
-| AI         | `copilot-chat`     | `ai.copilot-chat`        |
-| Coding     | `mini-surround`    | `coding.mini-surround`   |
-| Coding     | `yanky`            | `coding.yanky`           |
-| DAP        | `core`             | `dap.core`               |
-| Editor     | `aerial`           | `editor.aerial`          |
-| Editor     | `dial`             | `editor.dial`            |
-| Editor     | `harpoon2`         | `editor.harpoon2`        |
-| Editor     | `inc-rename`       | `editor.inc-rename`      |
-| Editor     | `mini-move`        | `editor.mini-move`       |
-| Editor     | `overseer`         | `editor.overseer`        |
-| Editor     | `telescope`        | `editor.telescope`       |
-| Formatting | `prettier`         | `formatting.prettier`    |
-| Lang       | `ansible`          | `lang.ansible`           |
-| Lang       | `docker`           | `lang.docker`            |
-| Lang       | `git`              | `lang.git`               |
-| Lang       | `json`             | `lang.json`              |
-| Lang       | `markdown`         | `lang.markdown`          |
-| Lang       | `python`           | `lang.python`            |
-| Lang       | `sql`              | `lang.sql`               |
-| Lang       | `tailwind`         | `lang.tailwind`          |
-| Lang       | `toml`             | `lang.toml`              |
-| Lang       | `typescript`       | `lang.typescript`        |
-| Lang       | `yaml`             | `lang.yaml`              |
-| Linting    | `eslint`           | `linting.eslint`         |
-| Test       | `core`             | `test.core`              |
-| UI         | `mini-indentscope` | `ui.mini-indentscope`    |
-| UI         | `treesitter-context` | `ui.treesitter-context` |
-| Util       | `dot`              | `util.dot`               |
-| Util       | `mini-hipatterns`  | `util.mini-hipatterns`   |
-| Util       | `project`          | `util.project`           |
 
 ## IdeaVim (JetBrains)
 
 [IdeaVim](https://github.com/JetBrains/ideavim) provides Vim emulation in
 JetBrains IDEs. The `<Leader>` key is `Space`.
 
-### IdeaVim Plugins
-
-| Plugin             | Description                          |
-| ------------------ | ------------------------------------ |
-| `easymotion`       | Jump to any visible character        |
-| `surround`         | Add/change/delete surrounding pairs  |
-| `commentary`       | Toggle line/block comments           |
-| `paragraph-motion` | Move by blank-line-delimited blocks  |
-| `nerdtree`         | File explorer sidebar                |
-| `which-key`        | Display available keybindings        |
-
-> **[IdeaVim Keymaps →](docs/ideavim.md)**
+> **[IdeaVim Details →](docs/ideavim.md)**

--- a/.github/README.md
+++ b/.github/README.md
@@ -23,8 +23,8 @@ yadm bootstrap
 
 ## Stack
 
-- 🖥️ **[Alacritty](https://github.com/alacritty/alacritty)** - Terminal emulator → [docs: keymaps](docs/alacritty.md)
-- 🐚 **[Zsh](https://www.zsh.org/)** - Shell with antidote and Starship → [docs: plugins, aliases & tools](docs/shell.md)
-- 💻 **[Tmux](https://github.com/tmux/tmux)** - Terminal multiplexer → [docs: plugins & keymaps](docs/tmux.md)
-- 🚀 **[Neovim](https://neovim.io)** - Terminal editor via LazyVim → [docs: keymaps](docs/neovim.md)
-- 🔧 **[IdeaVim](https://github.com/JetBrains/ideavim)** - Vim emulation in JetBrains → [docs: plugins & keymaps](docs/ideavim.md)
+- 🖥️ **[Alacritty](docs/alacritty.md)** - Terminal emulator
+- 🐚 **[Zsh](docs/shell.md)** - Shell with antidote and Starship
+- 💻 **[Tmux](docs/tmux.md)** - Terminal multiplexer
+- 🚀 **[Neovim](docs/neovim.md)** - Terminal editor via LazyVim
+- 🔧 **[IdeaVim](docs/ideavim.md)** - Vim emulation in JetBrains

--- a/.github/README.md
+++ b/.github/README.md
@@ -39,8 +39,9 @@ plugin manager and [Starship](https://starship.rs/) as the prompt.
 
 [Tmux](https://github.com/tmux/tmux) prefix is remapped to `C-a`. The status bar
 shows the ⚡ symbol when the prefix key is active. Use `<Prefix> m` to
-toggle mobile mode, which switches the prefix to `C-b`, hides status indicators,
-and shows a 📱 badge.
+toggle mobile mode, which switches the prefix to `C-b` (so shortcuts work
+correctly with mobile SSH/Mosh clients), hides status indicators, and shows a
+📱 badge.
 
 > **[Tmux Details →](docs/tmux.md)**
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -21,42 +21,12 @@ yadm config local.class Personal
 yadm bootstrap
 ```
 
-## Alacritty
+## Stack
 
-[Alacritty](https://github.com/alacritty/alacritty) is installed as the terminal
-emulator.
-
-> **[Alacritty Keymaps →](docs/alacritty.md)**
-
-## Shell (Zsh)
-
-Zsh is configured with [antidote](https://github.com/mattmc3/antidote) as the
-plugin manager and [Starship](https://starship.rs/) as the prompt.
-
-> **[Shell Details →](docs/shell.md)**
-
-## Tmux
-
-[Tmux](https://github.com/tmux/tmux) prefix is remapped to `C-a`. The status bar
-shows the ⚡ symbol when the prefix key is active. Use `<Prefix> m` to
-toggle mobile mode, which switches the prefix to `C-b` (so shortcuts work
-correctly with mobile SSH/Mosh clients), hides status indicators, and shows a
-📱 badge.
-
-> **[Tmux Details →](docs/tmux.md)**
-
-## Neovim (LazyVim)
-
-[Neovim](https://neovim.io) is configured using
-[LazyVim](https://github.com/LazyVim/LazyVim) as the base distribution. See the
-[LazyVim keymaps reference](https://www.lazyvim.org/keymaps) for all default
-keybindings. The `<Leader>` key is `Space`.
-
-> **[Neovim Keymaps →](docs/neovim.md)**
-
-## IdeaVim (JetBrains)
-
-[IdeaVim](https://github.com/JetBrains/ideavim) provides Vim emulation in
-JetBrains IDEs. The `<Leader>` key is `Space`.
-
-> **[IdeaVim Details →](docs/ideavim.md)**
+| Tool                                                               | Details                      |
+| ------------------------------------------------------------------ | ---------------------------- |
+| [Alacritty](https://github.com/alacritty/alacritty)                | [Details](docs/alacritty.md) |
+| [Zsh](https://www.zsh.org/)                                        | [Details](docs/shell.md)     |
+| [Tmux](https://github.com/tmux/tmux)                               | [Details](docs/tmux.md)      |
+| [Neovim](https://neovim.io) / [LazyVim](https://www.lazyvim.org/)  | [Details](docs/neovim.md)    |
+| [IdeaVim](https://github.com/JetBrains/ideavim)                    | [Details](docs/ideavim.md)   |

--- a/.github/docs/alacritty.md
+++ b/.github/docs/alacritty.md
@@ -2,7 +2,7 @@
 
 # 🚀 Alacritty Keymaps
 
-[Back to README](../README.md)
+> ⬅️ [Back to README](../README.md)
 
 ## Custom Keybindings
 

--- a/.github/docs/ideavim.md
+++ b/.github/docs/ideavim.md
@@ -2,7 +2,7 @@
 
 # 🔧 IdeaVim
 
-[Back to README](../README.md)
+> ⬅️ [Back to README](../README.md)
 
 Vim emulation in JetBrains IDEs. The `<Leader>` key is `Space`.
 

--- a/.github/docs/ideavim.md
+++ b/.github/docs/ideavim.md
@@ -4,8 +4,6 @@
 
 [Back to README](../README.md)
 
-The `<Leader>` key is `Space`.
-
 ## Plugins
 
 | Plugin             | Description                          |

--- a/.github/docs/ideavim.md
+++ b/.github/docs/ideavim.md
@@ -1,10 +1,21 @@
 <!-- markdownlint-disable MD013 -->
 
-# 🔧 IdeaVim Keymaps
+# 🔧 IdeaVim
 
 [Back to README](../README.md)
 
 The `<Leader>` key is `Space`.
+
+## Plugins
+
+| Plugin             | Description                          |
+| ------------------ | ------------------------------------ |
+| `easymotion`       | Jump to any visible character        |
+| `surround`         | Add/change/delete surrounding pairs  |
+| `commentary`       | Toggle line/block comments           |
+| `paragraph-motion` | Move by blank-line-delimited blocks  |
+| `nerdtree`         | File explorer sidebar                |
+| `which-key`        | Display available keybindings        |
 
 ## Navigation
 

--- a/.github/docs/ideavim.md
+++ b/.github/docs/ideavim.md
@@ -4,6 +4,8 @@
 
 [Back to README](../README.md)
 
+Vim emulation in JetBrains IDEs. The `<Leader>` key is `Space`.
+
 ## Plugins
 
 | Plugin             | Description                          |

--- a/.github/docs/neovim.md
+++ b/.github/docs/neovim.md
@@ -4,9 +4,6 @@
 
 [Back to README](../README.md)
 
-The `<Leader>` key is `Space`. For all default LazyVim keybindings, see the
-[LazyVim keymaps reference](https://www.lazyvim.org/keymaps).
-
 ## Custom Keybindings
 
 | Key                | Mode            | Description                                         |

--- a/.github/docs/neovim.md
+++ b/.github/docs/neovim.md
@@ -2,7 +2,7 @@
 
 # 🚀 Neovim Keymaps
 
-[Back to README](../README.md)
+> ⬅️ [Back to README](../README.md)
 
 Configured using [LazyVim](https://github.com/LazyVim/LazyVim) as the base
 distribution. See the

--- a/.github/docs/neovim.md
+++ b/.github/docs/neovim.md
@@ -4,6 +4,11 @@
 
 [Back to README](../README.md)
 
+Configured using [LazyVim](https://github.com/LazyVim/LazyVim) as the base
+distribution. See the
+[LazyVim keymaps reference](https://www.lazyvim.org/keymaps) for all default
+keybindings. The `<Leader>` key is `Space`.
+
 ## Custom Keybindings
 
 | Key                | Mode            | Description                                         |

--- a/.github/docs/shell.md
+++ b/.github/docs/shell.md
@@ -1,0 +1,58 @@
+<!-- markdownlint-disable MD013 -->
+
+# 🐚 Shell (Zsh)
+
+[Back to README](../README.md)
+
+## Zsh Plugins
+
+| Plugin                                                                          | Description                          |
+| ------------------------------------------------------------------------------- | ------------------------------------ |
+| [zsh-completions](https://github.com/zsh-users/zsh-completions)                | Additional completion definitions    |
+| [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions)         | Fish-like autosuggestions            |
+| [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) | Syntax highlighting at the prompt    |
+| [zsh-vim-mode](https://github.com/softmoth/zsh-vim-mode)                       | Vim keybindings for the command line |
+
+## Tool Integrations
+
+| Tool                                            | Description                             |
+| ----------------------------------------------- | --------------------------------------- |
+| [fzf](https://github.com/junegunn/fzf)          | Fuzzy finder (`C-r` for history search) |
+| [zoxide](https://github.com/ajeetdsouza/zoxide) | Smarter `cd` (aliased to `cd`)          |
+| [mise](https://github.com/jdx/mise)             | Runtime version management              |
+| [Starship](https://starship.rs/)                | Cross-shell prompt                      |
+
+## Key Aliases
+
+| Alias | Expands To                                                  |
+| ----- | ----------------------------------------------------------- |
+| `v`   | `nvim`                                                      |
+| `lg`  | `lazygit`                                                   |
+| `ly`  | `lazyyadm` (lazygit for yadm files)                         |
+| `ls`  | `eza`                                                       |
+| `ll`  | `eza -la --header --git --icons --changed --time-style=iso` |
+| `cat` | `bat` (interactive terminals only)                          |
+| `cd`  | `z` (zoxide, interactive terminals only)                    |
+| `f`   | `open -a Finder ./` (macOS only)                            |
+
+## CLI Utilities
+
+| Utility       | Description                                                          | Link                                                |
+| ------------- | -------------------------------------------------------------------- | --------------------------------------------------- |
+| `mise`        | Runtime version management (replaces pyenv/rbenv/nvm).               | [Link](https://github.com/jdx/mise)                 |
+| `uv`          | Python package and project manager.                                  | [Link](https://github.com/astral-sh/uv)             |
+| `starship`    | Cross-shell prompt.                                                  | [Link](https://starship.rs/)                        |
+| `bat`         | A `cat` clone with syntax highlighting and Git integration.          | [Link](https://github.com/sharkdp/bat)              |
+| `fd`          | A simple, fast, and user-friendly alternative to `find`.             | [Link](https://github.com/sharkdp/fd)               |
+| `fzf`         | A general-purpose command-line fuzzy finder.                         | [Link](https://github.com/junegunn/fzf)             |
+| `gh`          | GitHub's official CLI tool for managing repositories.                | [Link](https://cli.github.com)                      |
+| `git-delta`   | A viewer for git and diff output with syntax highlighting.           | [Link](https://github.com/dandavison/delta)         |
+| `lazygit`     | A simple terminal UI for git commands.                               | [Link](https://github.com/jesseduffield/lazygit)    |
+| `jq`          | A lightweight and flexible command-line JSON processor.              | [Link](https://github.com/stedolan/jq)              |
+| `macos-trash` | A command-line interface to the macOS trash (e.g, `trash file.txt`). | [Link](https://github.com/sindresorhus/macos-trash) |
+| `ripgrep`     | A fast line-oriented search tool, like `grep` with steroids.         | [Link](https://github.com/BurntSushi/ripgrep)       |
+| `tealdeer`    | More readable `man` pages (e.g., `tldr grep`)                        | [Link](https://github.com/dbrgn/tealdeer)           |
+| `tmuxinator`  | Define and manage tmux session layouts via YAML.                     | [Link](https://github.com/tmuxinator/tmuxinator)    |
+| `tree`        | A recursive directory listing command with tree-like output.         | [Link](http://mama.indstate.edu/users/ice/tree)     |
+| `eza`         | Modern replacement for `ls`.                                         | [Link](https://github.com/eza-community/eza)        |
+| `zoxide`      | A smarter `cd` command.                                              | [Link](https://github.com/ajeetdsouza/zoxide)       |

--- a/.github/docs/shell.md
+++ b/.github/docs/shell.md
@@ -2,7 +2,7 @@
 
 # 🐚 Shell (Zsh)
 
-[Back to README](../README.md)
+> ⬅️ [Back to README](../README.md)
 
 Configured with [antidote](https://github.com/mattmc3/antidote) as the plugin
 manager and [Starship](https://starship.rs/) as the prompt.

--- a/.github/docs/shell.md
+++ b/.github/docs/shell.md
@@ -4,6 +4,9 @@
 
 [Back to README](../README.md)
 
+Configured with [antidote](https://github.com/mattmc3/antidote) as the plugin
+manager and [Starship](https://starship.rs/) as the prompt.
+
 ## Zsh Plugins
 
 | Plugin                                                                          | Description                          |

--- a/.github/docs/tmux.md
+++ b/.github/docs/tmux.md
@@ -2,7 +2,7 @@
 
 # 💻 Tmux
 
-[Back to README](../README.md)
+> ⬅️ [Back to README](../README.md)
 
 Prefix is remapped to `C-a`. The status bar shows the ⚡ symbol when the prefix
 key is active. Use `<Prefix> m` to toggle mobile mode, which switches the prefix

--- a/.github/docs/tmux.md
+++ b/.github/docs/tmux.md
@@ -1,8 +1,26 @@
 <!-- markdownlint-disable MD013 -->
 
-# 💻 Tmux Keymaps
+# 💻 Tmux
 
 [Back to README](../README.md)
+
+## Plugins
+
+Plugins installed via [TPM](https://github.com/tmux-plugins/tpm), plus
+[tmuxinator](https://github.com/tmuxinator/tmuxinator) as a companion tool for
+session layouts:
+
+| Plugin                                                                  | Description                                                     |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------- |
+| [catppuccin/tmux](https://github.com/catppuccin/tmux)                    | Status bar theme (Mocha flavor)                                 |
+| [tmux-cpu](https://github.com/tmux-plugins/tmux-cpu)                    | CPU usage indicator in status bar                               |
+| [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect)        | Save and restore tmux sessions across restarts                  |
+| [tmux-yank](https://github.com/tmux-plugins/tmux-yank)                  | Copy to system clipboard from tmux copy mode                    |
+| [vim-tmux-navigator](https://github.com/christoomey/vim-tmux-navigator) | Seamless navigation between tmux panes and Vim splits           |
+| [tmux-fuzzback](https://github.com/roosta/tmux-fuzzback)                | Fuzzy search scrollback buffer via fzf popup                    |
+| [extrakto](https://github.com/laktak/extrakto)                          | Extract and select tokens (URLs, paths, hashes) from scrollback |
+| [tmux-sessionx](https://github.com/omerxx/tmux-sessionx)                | Fuzzy session picker with zoxide and tmuxinator integration     |
+| [tmuxinator](https://github.com/tmuxinator/tmuxinator)                  | Define and manage tmux session layouts via YAML                 |
 
 ## Prefix
 

--- a/.github/docs/tmux.md
+++ b/.github/docs/tmux.md
@@ -4,6 +4,11 @@
 
 [Back to README](../README.md)
 
+Prefix is remapped to `C-a`. The status bar shows the ⚡ symbol when the prefix
+key is active. Use `<Prefix> m` to toggle mobile mode, which switches the prefix
+to `C-b` (so shortcuts work correctly with mobile SSH/Mosh clients), hides
+status indicators, and shows a 📱 badge.
+
 ## Plugins
 
 Plugins installed via [TPM](https://github.com/tmux-plugins/tpm), plus

--- a/.github/docs/tmux.md
+++ b/.github/docs/tmux.md
@@ -22,13 +22,6 @@ session layouts:
 | [tmux-sessionx](https://github.com/omerxx/tmux-sessionx)                | Fuzzy session picker with zoxide and tmuxinator integration     |
 | [tmuxinator](https://github.com/tmuxinator/tmuxinator)                  | Define and manage tmux session layouts via YAML                 |
 
-## Prefix
-
-The prefix is remapped to `C-a` (default `C-b`). A ⚡ indicator appears in the
-status bar when the prefix key is active. Use `<Prefix> m` to toggle mobile
-mode, which switches the prefix to `C-b`, hides status indicators, and shows a
-📱 badge.
-
 ## Custom Keybindings
 
 | Keybinding            | Description                                               |


### PR DESCRIPTION
## Summary
- Move Zsh plugins, tool integrations, aliases, and CLI utilities into a new `docs/shell.md` sub-page
- Move Tmux plugins table into `docs/tmux.md` and IdeaVim plugins table into `docs/ideavim.md`
- Remove Enabled LazyVim Extras table entirely
- Remove redundant prose ("Tmux is the terminal multiplexer.", "Only custom overrides...")

## Test plan
- [ ] Verify all sub-page links in README resolve correctly
- [ ] Confirm no content was lost — tables appear in their new sub-pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)