### PR TITLE
Update LazyVim extras

### DIFF
--- a/.config/lazyvim/lazyvim.json
+++ b/.config/lazyvim/lazyvim.json
@@ -1,13 +1,16 @@
 {
   "extras": [
+    "lazyvim.plugins.extras.ai.claudecode",
     "lazyvim.plugins.extras.ai.copilot",
     "lazyvim.plugins.extras.ai.copilot-chat",
+    "lazyvim.plugins.extras.coding.mini-comment",
     "lazyvim.plugins.extras.coding.mini-surround",
     "lazyvim.plugins.extras.coding.yanky",
     "lazyvim.plugins.extras.dap.core",
     "lazyvim.plugins.extras.editor.aerial",
-    "lazyvim.plugins.extras.editor.dial",
+    "lazyvim.plugins.extras.editor.illuminate",
     "lazyvim.plugins.extras.editor.inc-rename",
+    "lazyvim.plugins.extras.editor.mini-files",
     "lazyvim.plugins.extras.editor.mini-move",
     "lazyvim.plugins.extras.editor.neo-tree",
     "lazyvim.plugins.extras.editor.overseer",
@@ -29,8 +32,7 @@
     "lazyvim.plugins.extras.ui.mini-indentscope",
     "lazyvim.plugins.extras.ui.treesitter-context",
     "lazyvim.plugins.extras.util.dot",
-    "lazyvim.plugins.extras.util.mini-hipatterns",
-    "lazyvim.plugins.extras.util.project"
+    "lazyvim.plugins.extras.util.mini-hipatterns"
   ],
   "news": {
     "NEWS.md": "11866"


### PR DESCRIPTION
## Summary
- Add extras: `ai.claudecode`, `coding.mini-comment`, `editor.illuminate`, `editor.mini-files`
- Remove extras: `editor.dial`, `util.project`
- Entries kept in alphabetical order

## Test plan
- [ ] Open nvim and run `:Lazy` to confirm all extras load without errors
- [ ] Verify removed extras no longer appear in the plugin list

🤖 Generated with [Claude Code](https://claude.com/claude-code)