### PR TITLE
fix tmux status bar not updating session name on switch

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -156,7 +156,7 @@ run '~/.config/tmux/plugins/tmux/catppuccin.tmux'
 set -g status-left ""
 set -g status-right-length 100
 set -g  status-right "#{?client_prefix,#[fg=#{@thm_peach}] ⚡#[default],}"
-set -agF status-right '#{E:@catppuccin_status_session}'
+set -ag status-right '#{E:@catppuccin_status_session}'
 set -agF status-right '#{E:@catppuccin_status_cpu}'
 set -gu @mobile_mode
 


### PR DESCRIPTION
## Summary
- Remove `-F` flag from `set -agF status-right '#{E:@catppuccin_status_session}'` so the session name format (`#S`) is expanded dynamically on each status refresh rather than being baked in at config load time
- This fixes the session name in the status bar not updating when switching between tmux sessions

## Test plan
- [x] Switch between tmux sessions and verify the status bar updates automatically without needing `prefix + r`

🤖 Generated with [Claude Code](https://claude.com/claude-code)