### PR TITLE
Add Lua and shell formatting/linting checks

### DIFF
--- a/.github/workflows/lua-checks.yml
+++ b/.github/workflows/lua-checks.yml
@@ -1,0 +1,77 @@
+name: Lint & Format Checks
+
+on:
+  push:
+    branches: [main, "claude/**"]
+    paths:
+      - ".config/lazyvim/**/*.lua"
+      - ".config/nvim/**/*.lua"
+      - ".nvim.lua"
+      - ".stylua.toml"
+      - ".luacheckrc"
+      - ".config/yadm/bootstrap##*"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".config/lazyvim/**/*.lua"
+      - ".config/nvim/**/*.lua"
+      - ".nvim.lua"
+      - ".stylua.toml"
+      - ".luacheckrc"
+      - ".config/yadm/bootstrap##*"
+
+jobs:
+  lua-format:
+    name: Lua Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stylua
+        uses: JohnnyMorganz/stylua-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
+          args: --check .config/lazyvim/ .config/nvim/ .nvim.lua
+
+  lua-lint:
+    name: Lua Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Lua and luarocks
+        uses: leafo/gh-actions-lua@v10
+        with:
+          luaVersion: "5.1"
+
+      - uses: leafo/gh-actions-luarocks@v4
+
+      - name: Install luacheck
+        run: luarocks install luacheck
+
+      - name: Run luacheck
+        run: luacheck .config/lazyvim/ .config/nvim/ .nvim.lua
+
+  shell-format:
+    name: Shell Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shfmt
+        run: |
+          curl -sS https://webi.sh/shfmt | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Check shell formatting
+        run: shfmt -i 4 -d ".config/yadm/bootstrap##distro.Ubuntu" ".config/yadm/bootstrap##os.Darwin"
+
+  shell-lint:
+    name: Shell Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run shellcheck
+        run: shellcheck ".config/yadm/bootstrap##distro.Ubuntu" ".config/yadm/bootstrap##os.Darwin"

--- a/.local/bin/lint-check.sh
+++ b/.local/bin/lint-check.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LUA_TARGETS=(
+  "$HOME/.config/lazyvim/"
+  "$HOME/.config/nvim/"
+  "$HOME/.nvim.lua"
+)
+
+SHELL_TARGETS=(
+  "$HOME/.config/yadm/bootstrap##distro.Ubuntu"
+  "$HOME/.config/yadm/bootstrap##os.Darwin"
+)
+
+usage() {
+  echo "Usage: lint-check.sh <command>"
+  echo ""
+  echo "Commands:"
+  echo "  format       Auto-format all files (Lua + shell)"
+  echo "  check        Check formatting without modifying files"
+  echo "  lint         Run linters (luacheck + shellcheck)"
+  echo "  all          Run check + lint"
+  echo ""
+  echo "  lua-format   Auto-format Lua files with stylua"
+  echo "  lua-check    Check Lua formatting"
+  echo "  lua-lint     Run luacheck"
+  echo ""
+  echo "  sh-format    Auto-format shell files with shfmt"
+  echo "  sh-check     Check shell formatting"
+  echo "  sh-lint      Run shellcheck"
+  exit 1
+}
+
+# Lua commands
+cmd_lua_format() {
+  echo "Formatting Lua files with stylua..."
+  stylua "${LUA_TARGETS[@]}"
+  echo "Done."
+}
+
+cmd_lua_check() {
+  echo "Checking Lua formatting with stylua..."
+  stylua --check "${LUA_TARGETS[@]}"
+  echo "Lua formatting OK."
+}
+
+cmd_lua_lint() {
+  echo "Linting Lua files with luacheck..."
+  luacheck "${LUA_TARGETS[@]}"
+  echo "Lua linting OK."
+}
+
+# Shell commands
+cmd_sh_format() {
+  echo "Formatting shell files with shfmt..."
+  shfmt -i 4 -w "${SHELL_TARGETS[@]}"
+  echo "Done."
+}
+
+cmd_sh_check() {
+  echo "Checking shell formatting with shfmt..."
+  shfmt -i 4 -d "${SHELL_TARGETS[@]}"
+  echo "Shell formatting OK."
+}
+
+cmd_sh_lint() {
+  echo "Linting shell files with shellcheck..."
+  shellcheck "${SHELL_TARGETS[@]}"
+  echo "Shell linting OK."
+}
+
+# Combined commands
+cmd_format() {
+  cmd_lua_format
+  echo ""
+  cmd_sh_format
+}
+
+cmd_check() {
+  cmd_lua_check
+  echo ""
+  cmd_sh_check
+}
+
+cmd_lint() {
+  cmd_lua_lint
+  echo ""
+  cmd_sh_lint
+}
+
+cmd_all() {
+  cmd_check
+  echo ""
+  cmd_lint
+}
+
+case "${1:-}" in
+  format)     cmd_format ;;
+  check)      cmd_check ;;
+  lint)       cmd_lint ;;
+  all)        cmd_all ;;
+  lua-format) cmd_lua_format ;;
+  lua-check)  cmd_lua_check ;;
+  lua-lint)   cmd_lua_lint ;;
+  sh-format)  cmd_sh_format ;;
+  sh-check)   cmd_sh_check ;;
+  sh-lint)    cmd_sh_lint ;;
+  *)          usage ;;
+esac

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,15 @@
+-- Luacheck configuration for Neovim dotfiles
+globals = {
+  "vim",
+}
+
+max_line_length = 120
+
+-- Suppress common Neovim config false positives
+ignore = {
+  "111", -- setting non-standard global variable (M = {} module pattern)
+  "112", -- mutating non-standard global variable (M.func = ...)
+  "113", -- accessing undefined variable (return M)
+  "212", -- unused argument (common in callbacks)
+  "213", -- unused loop variable (common with _ placeholder)
+}


### PR DESCRIPTION
## Summary
- Add `.luacheckrc` for Neovim-aware Lua linting (allows `vim` global, suppresses module pattern noise)
- Add `~/.local/bin/lint-check.sh` helper script with subcommands for Lua and shell formatting/linting
- Add GitHub Actions workflow with 4 jobs: lua-format, lua-lint, shell-format, shell-lint
- Targets: `.config/lazyvim/`, `.config/nvim/`, `.nvim.lua` (Lua) and `.config/yadm/bootstrap##*` (shell)

## Test plan
- [ ] Run `lint-check.sh all` locally to verify checks pass
- [ ] Verify GitHub Actions workflow runs on this PR
- [ ] Confirm `lint-check.sh format` auto-formats without breaking anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)