### PR TITLE
Add catch-all gitignore to fix git process pileup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Ignore everything by default. yadm tracks files explicitly, so this only
+# affects untracked files. Without this, git status scans the entire home
+# directory, causing editor plugins (gitsigns, lualine, etc.) to hang.
+*
+
 **/.DS_Store
 .CFUserTextEncoding
 .NERDTreeBookmarks


### PR DESCRIPTION
## Summary
- Adds `*` as the first rule in `~/.gitignore` so git ignores all untracked files by default
- Prevents `git status` from scanning the entire home directory, which caused editor plugins (gitsigns, lualine, etc.) to spawn dozens of hanging git processes
- No impact on yadm-tracked files since yadm adds files explicitly

## Test plan
- [x] Verified `yadm status` completes in ~0.4s (previously would hang)
- [ ] Open LazyVim from `~` and confirm no git process pileup in Activity Monitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)