### PR TITLE
LazyVim keymaps, scratch config, and tmux layout shortcuts

### DIFF
--- a/.config/lazyvim/lua/plugins/diffview.lua
+++ b/.config/lazyvim/lua/plugins/diffview.lua
@@ -2,7 +2,7 @@ return {
   "sindrets/diffview.nvim",
   cmd = { "DiffviewOpen", "DiffviewFileHistory", "DiffviewClose" },
   keys = {
-    { "<leader>gq", "<cmd>DiffviewClose<cr>" },
+    { "<leader>gq", "<cmd>DiffviewClose<cr>", desc = "DiffviewClose" },
   },
   opts = {
     view = {

--- a/.config/lazyvim/lua/plugins/diffview.lua
+++ b/.config/lazyvim/lua/plugins/diffview.lua
@@ -1,6 +1,9 @@
 return {
   "sindrets/diffview.nvim",
   cmd = { "DiffviewOpen", "DiffviewFileHistory", "DiffviewClose" },
+  keys = {
+    { "<leader>gq", "<cmd>DiffviewClose<cr>", desc = "DiffviewClose" },
+  },
   opts = {
     view = {
       default = {

--- a/.config/lazyvim/lua/plugins/diffview.lua
+++ b/.config/lazyvim/lua/plugins/diffview.lua
@@ -2,7 +2,7 @@ return {
   "sindrets/diffview.nvim",
   cmd = { "DiffviewOpen", "DiffviewFileHistory", "DiffviewClose" },
   keys = {
-    { "<leader>gq", "<cmd>DiffviewClose<cr>", desc = "DiffviewClose" },
+    { "<leader>gq", "<cmd>DiffviewClose<cr>" },
   },
   opts = {
     view = {

--- a/.config/lazyvim/lua/plugins/diffview.lua
+++ b/.config/lazyvim/lua/plugins/diffview.lua
@@ -2,6 +2,7 @@ return {
   "sindrets/diffview.nvim",
   cmd = { "DiffviewOpen", "DiffviewFileHistory", "DiffviewClose" },
   keys = {
+    { "<leader>go", ":DiffviewOpen ", desc = "DiffviewOpen" },
     { "<leader>gq", "<cmd>DiffviewClose<cr>", desc = "DiffviewClose" },
   },
   opts = {

--- a/.config/lazyvim/lua/plugins/grug_far.lua
+++ b/.config/lazyvim/lua/plugins/grug_far.lua
@@ -1,0 +1,11 @@
+return {
+  "MagicDuck/grug-far.nvim",
+  keys = {
+    {
+      "<leader>ss",
+      ":GrugFarWithin<cr>",
+      mode = "x",
+      desc = "Search and Replace (selection)",
+    },
+  },
+}

--- a/.config/lazyvim/lua/plugins/grug_far.lua
+++ b/.config/lazyvim/lua/plugins/grug_far.lua
@@ -5,6 +5,7 @@ return {
       "<leader>ss",
       ":GrugFarWithin<cr>",
       mode = "x",
+      desc = "Search and Replace (selection)",
     },
   },
 }

--- a/.config/lazyvim/lua/plugins/grug_far.lua
+++ b/.config/lazyvim/lua/plugins/grug_far.lua
@@ -5,7 +5,6 @@ return {
       "<leader>ss",
       ":GrugFarWithin<cr>",
       mode = "x",
-      desc = "Search and Replace (selection)",
     },
   },
 }

--- a/.config/lazyvim/lua/plugins/incline.lua
+++ b/.config/lazyvim/lua/plugins/incline.lua
@@ -51,7 +51,20 @@ return {
         { " " },
       }
 
+      -- Truncate parent path from the left to fit the available window width,
+      -- keeping the filename always fully visible.
       if parent ~= "." then
+        local inc_win_width = vim.api.nvim_win_get_width(props.win)
+        local inc_max_width = math.floor(inc_win_width * 0.7)
+        -- 4 = icon(1) + space(1) + padding(2), 1 = trailing slash
+        local inc_budget = inc_max_width - #filename - 4 - 1
+        if inc_budget > 0 and #parent > inc_budget then
+          parent = "…" .. parent:sub(-(inc_budget - 1))
+          local inc_slash_pos = parent:find("/", 2)
+          if inc_slash_pos then
+            parent = "…" .. parent:sub(inc_slash_pos)
+          end
+        end
         table.insert(result, { parent .. "/", guifg = path_fg })
       end
 
@@ -69,8 +82,7 @@ return {
     },
 
     window = {
-      width = 0.4, -- cap at 40% of window width to avoid covering content
-      placement = { horizontal = "right", vertical = "top" },
+placement = { horizontal = "right", vertical = "top" },
       padding = { left = 1, right = 1 },
       margin = { horizontal = 0, vertical = 1 },
     },

--- a/.config/lazyvim/lua/plugins/neo_tree.lua
+++ b/.config/lazyvim/lua/plugins/neo_tree.lua
@@ -11,22 +11,7 @@ end
 return {
   "nvim-neo-tree/neo-tree.nvim",
   dependencies = {
-    {
-      "s1n7ax/nvim-window-picker",
-      version = "2.*",
-      config = function()
-        require("window-picker").setup({
-          hint = "floating-big-letter",
-          selection_chars = "ABCDEFGHIJKL",
-          filter_rules = {
-            bo = {
-              filetype = { "neo-tree", "neo-tree-popup", "notify", "NvimTree" },
-              buftype = { "terminal", "quickfix" },
-            },
-          },
-        })
-      end,
-    },
+    "s1n7ax/nvim-window-picker",
   },
   opts = {
     -- Show hidden/filtered files (e.g., dotfiles) in the tree

--- a/.config/lazyvim/lua/plugins/snacks.lua
+++ b/.config/lazyvim/lua/plugins/snacks.lua
@@ -3,8 +3,9 @@ return {
   opts = {
     scratch = {
       win = {
-        width = 0.8,
+        width = 120,
         height = 0.75,
+        wo = { wrap = true, linebreak = true },
       },
     },
   },

--- a/.config/lazyvim/lua/plugins/snacks.lua
+++ b/.config/lazyvim/lua/plugins/snacks.lua
@@ -1,5 +1,23 @@
 return {
   "folke/snacks.nvim",
+  keys = {
+    {
+      "<leader>gy",
+      desc = "Lazygit yadm",
+      function()
+        Snacks.lazygit({
+          args = {
+            "--use-config-file",
+            vim.env.HOME .. "/.config/yadm/lazygit.yml," .. vim.env.HOME .. "/.config/lazygit/config.yml",
+            "--work-tree",
+            vim.env.HOME,
+            "--git-dir",
+            vim.env.HOME .. "/.local/share/yadm/repo.git",
+          },
+        })
+      end,
+    },
+  },
   opts = {
     scratch = {
       win = {

--- a/.config/lazyvim/lua/plugins/snacks.lua
+++ b/.config/lazyvim/lua/plugins/snacks.lua
@@ -3,7 +3,7 @@ return {
   keys = {
     {
       "<leader>gy",
-      desc = "Lazygit yadm",
+      desc = "Lazygit (yadm)",
       function()
         Snacks.lazygit({
           args = {

--- a/.config/lazyvim/lua/plugins/snacks.lua
+++ b/.config/lazyvim/lua/plugins/snacks.lua
@@ -1,0 +1,11 @@
+return {
+  "folke/snacks.nvim",
+  opts = {
+    scratch = {
+      win = {
+        width = 0.8,
+        height = 0.75,
+      },
+    },
+  },
+}

--- a/.config/lazyvim/lua/plugins/telescope.lua
+++ b/.config/lazyvim/lua/plugins/telescope.lua
@@ -63,7 +63,7 @@ return {
     -- add custom keymaps to existing keymaps
     table.insert(_keys, { "<leader>fI", find_files_no_ignore })
     table.insert(_keys, { "<leader>fyf", yadm_find_files })
-    table.insert(_keys, { "<leader>fyp", yadm_live_grep })
+    table.insert(_keys, { "<leader>fyg", yadm_live_grep })
     table.insert(_keys, { "<leader>sQ", builtin.quickfixhistory })
 
     return _keys

--- a/.config/lazyvim/lua/plugins/telescope.lua
+++ b/.config/lazyvim/lua/plugins/telescope.lua
@@ -61,10 +61,10 @@ return {
     end
 
     -- add custom keymaps to existing keymaps
-    table.insert(_keys, { "<leader>fI", find_files_no_ignore, desc = "Find Files (no ignore)" })
-    table.insert(_keys, { "<leader>fyf", yadm_find_files, desc = "Find yadm Files" })
-    table.insert(_keys, { "<leader>fyp", yadm_live_grep, desc = "Search yadm files with gre(p)" })
-    table.insert(_keys, { "<leader>sQ", builtin.quickfixhistory, desc = "Quickfix History" })
+    table.insert(_keys, { "<leader>fI", find_files_no_ignore })
+    table.insert(_keys, { "<leader>fyf", yadm_find_files })
+    table.insert(_keys, { "<leader>fyp", yadm_live_grep })
+    table.insert(_keys, { "<leader>sQ", builtin.quickfixhistory })
 
     return _keys
   end,

--- a/.config/lazyvim/lua/plugins/telescope.lua
+++ b/.config/lazyvim/lua/plugins/telescope.lua
@@ -61,10 +61,10 @@ return {
     end
 
     -- add custom keymaps to existing keymaps
-    table.insert(_keys, { "<leader>fI", find_files_no_ignore })
-    table.insert(_keys, { "<leader>fyf", yadm_find_files })
-    table.insert(_keys, { "<leader>fyg", yadm_live_grep })
-    table.insert(_keys, { "<leader>sQ", builtin.quickfixhistory })
+    table.insert(_keys, { "<leader>fI", find_files_no_ignore, desc = "Find Files (no ignore)" })
+    table.insert(_keys, { "<leader>fyf", yadm_find_files, desc = "Find yadm Files" })
+    table.insert(_keys, { "<leader>fyg", yadm_live_grep, desc = "Grep yadm Files" })
+    table.insert(_keys, { "<leader>sQ", builtin.quickfixhistory, desc = "Quickfix History" })
 
     return _keys
   end,

--- a/.config/lazyvim/lua/plugins/which_key.lua
+++ b/.config/lazyvim/lua/plugins/which_key.lua
@@ -4,6 +4,7 @@ return {
     spec = {
       { "<leader>fy", group = "yadm", icon = { icon = "󰊢 ", color = "orange" } },
       { "<leader>y", group = "yank", icon = { icon = "󰆏 ", color = "yellow" }, mode = { "n", "v" } },
+      { "<leader>ss", icon = { icon = "󰛔 ", color = "blue" }, mode = "x" },
     },
   },
 }

--- a/.config/lazyvim/lua/plugins/which_key.lua
+++ b/.config/lazyvim/lua/plugins/which_key.lua
@@ -4,7 +4,13 @@ return {
     spec = {
       { "<leader>fy", group = "yadm", icon = { icon = "󰊢 ", color = "orange" } },
       { "<leader>y", group = "yank", icon = { icon = "󰆏 ", color = "yellow" }, mode = { "n", "v" } },
-      { "<leader>ss", icon = { icon = "󰛔 ", color = "blue" }, mode = "x" },
+      { "<leader>fI", desc = "Find Files (no ignore)" },
+      { "<leader>fyf", desc = "Find yadm Files" },
+      { "<leader>fyp", desc = "Search yadm files with gre(p)" },
+      { "<leader>sQ", desc = "Quickfix History" },
+      { "<leader>gq", desc = "DiffviewClose" },
+      { "<leader>bm", desc = "Move Buffer to Window" },
+      { "<leader>ss", desc = "Search and Replace (selection)", icon = { icon = "󰛔 ", color = "blue" }, mode = "x" },
     },
   },
 }

--- a/.config/lazyvim/lua/plugins/which_key.lua
+++ b/.config/lazyvim/lua/plugins/which_key.lua
@@ -4,13 +4,7 @@ return {
     spec = {
       { "<leader>fy", group = "yadm", icon = { icon = "󰊢 ", color = "orange" } },
       { "<leader>y", group = "yank", icon = { icon = "󰆏 ", color = "yellow" }, mode = { "n", "v" } },
-      { "<leader>fI", desc = "Find Files (no ignore)" },
-      { "<leader>fyf", desc = "Find yadm Files" },
-      { "<leader>fyg", desc = "Grep yadm Files" },
-      { "<leader>sQ", desc = "Quickfix History" },
-      { "<leader>gq", desc = "DiffviewClose" },
-      { "<leader>bm", desc = "Move Buffer to Window" },
-      { "<leader>ss", desc = "Search and Replace (selection)", icon = { icon = "󰛔 ", color = "blue" }, mode = "x" },
+      { "<leader>ss", icon = { icon = "󰛔 ", color = "blue" }, mode = "x" },
     },
   },
 }

--- a/.config/lazyvim/lua/plugins/which_key.lua
+++ b/.config/lazyvim/lua/plugins/which_key.lua
@@ -4,6 +4,7 @@ return {
     spec = {
       { "<leader>fy", group = "yadm", icon = { icon = "󰊢 ", color = "orange" } },
       { "<leader>y", group = "yank", icon = { icon = "󰆏 ", color = "yellow" }, mode = { "n", "v" } },
+      { "<leader>gy", icon = { icon = "󰊢 ", color = "orange" } },
       { "<leader>ss", icon = { icon = "󰛔 ", color = "blue" }, mode = "x" },
     },
   },

--- a/.config/lazyvim/lua/plugins/which_key.lua
+++ b/.config/lazyvim/lua/plugins/which_key.lua
@@ -6,7 +6,7 @@ return {
       { "<leader>y", group = "yank", icon = { icon = "󰆏 ", color = "yellow" }, mode = { "n", "v" } },
       { "<leader>fI", desc = "Find Files (no ignore)" },
       { "<leader>fyf", desc = "Find yadm Files" },
-      { "<leader>fyp", desc = "Search yadm files with gre(p)" },
+      { "<leader>fyg", desc = "Grep yadm Files" },
       { "<leader>sQ", desc = "Quickfix History" },
       { "<leader>gq", desc = "DiffviewClose" },
       { "<leader>bm", desc = "Move Buffer to Window" },

--- a/.config/lazyvim/lua/plugins/window_picker.lua
+++ b/.config/lazyvim/lua/plugins/window_picker.lua
@@ -17,6 +17,7 @@ return {
   keys = {
     {
       "<leader>bm",
+      desc = "Move Buffer to Window",
       function()
         local wp_target_win = require("window-picker").pick_window()
         if not wp_target_win then

--- a/.config/lazyvim/lua/plugins/window_picker.lua
+++ b/.config/lazyvim/lua/plugins/window_picker.lua
@@ -26,6 +26,7 @@ return {
         local wp_target_buf = vim.api.nvim_win_get_buf(wp_target_win)
         vim.api.nvim_win_set_buf(wp_target_win, wp_current_buf)
         vim.api.nvim_win_set_buf(0, wp_target_buf)
+        vim.api.nvim_set_current_win(wp_target_win)
       end,
     },
   },

--- a/.config/lazyvim/lua/plugins/window_picker.lua
+++ b/.config/lazyvim/lua/plugins/window_picker.lua
@@ -27,7 +27,6 @@ return {
         vim.api.nvim_win_set_buf(wp_target_win, wp_current_buf)
         vim.api.nvim_win_set_buf(0, wp_target_buf)
       end,
-      desc = "Move Buffer to Window",
     },
   },
 }

--- a/.config/lazyvim/lua/plugins/window_picker.lua
+++ b/.config/lazyvim/lua/plugins/window_picker.lua
@@ -1,0 +1,33 @@
+return {
+  "s1n7ax/nvim-window-picker",
+  version = "2.*",
+  opts = {
+    hint = "floating-big-letter",
+    selection_chars = "ABCDEFGHIJKL",
+    filter_rules = {
+      autoselect_one = false,
+      include_current_win = false,
+      bo = {
+        filetype = { "neo-tree", "neo-tree-popup", "notify", "NvimTree" },
+        buftype = { "terminal", "quickfix" },
+      },
+    },
+  },
+  -- Pick a target window, then swap the current buffer into it
+  keys = {
+    {
+      "<leader>bm",
+      function()
+        local wp_target_win = require("window-picker").pick_window()
+        if not wp_target_win then
+          return
+        end
+        local wp_current_buf = vim.api.nvim_get_current_buf()
+        local wp_target_buf = vim.api.nvim_win_get_buf(wp_target_win)
+        vim.api.nvim_win_set_buf(wp_target_win, wp_current_buf)
+        vim.api.nvim_win_set_buf(0, wp_target_buf)
+      end,
+      desc = "Move Buffer to Window",
+    },
+  },
+}

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -103,6 +103,11 @@ bind-key -r -T prefix C-Right resize-pane -R 5
 unbind M-Left
 bind-key -r -T prefix C-Left resize-pane -L 5
 
+# layout shortcuts
+bind 1 select-layout even-horizontal
+bind 2 select-layout even-vertical
+bind 3 select-layout main-vertical \; swap-pane -s 0 -t 1
+
 # List of plugins
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'catppuccin/tmux#v2.1.3'


### PR DESCRIPTION
## Summary
- Add DiffviewClose keymap and buffer-to-window swap via window-picker
- Add GrugFarWithin visual keymap and improve incline path truncation
- Configure scratch window size (80%x75%) and soft wrap
- Add tmux layout shortcut keybindings (prefix + 1/2/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)