### PR TITLE
Misc config cleanup and disable unused rtp plugins

### DIFF
--- a/.Brewfile
+++ b/.Brewfile
@@ -32,7 +32,7 @@ brew "jq"
 brew "lazygit"
 brew "libevent"
 brew "libyaml"
-brew "lua"
+brew "lua@5.4", link: true
 brew "luarocks"
 brew "macos-trash"
 brew "markdownlint-cli"

--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -4,6 +4,6 @@ git:
       pager: delta --dark --paging=never
 gui:
   showIcons: true
-  nerdFontsVersion: 3
+  nerdFontsVersion: "3"
 os:
   editPreset: "nvim"

--- a/.config/lazyvim/lua/config/keymaps.lua
+++ b/.config/lazyvim/lua/config/keymaps.lua
@@ -1,12 +1,7 @@
 -- Keymaps are automatically loaded on the VeryLazy event
 -- Default keymaps that are always set: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/keymaps.lua
 
--- Wrapper around vim.keymap.set that defaults to silent mappings
-local function map(mode, lhs, rhs, opts)
-  opts = opts or {}
-  opts.silent = opts.silent ~= false
-  vim.keymap.set(mode, lhs, rhs, opts)
-end
+local map = LazyVim.safe_keymap_set
 
 -- Yank relative path to clipboard (e.g., src/file.lua)
 map("n", "<leader>yp", function()

--- a/.config/lazyvim/lua/config/lazy.lua
+++ b/.config/lazyvim/lua/config/lazy.lua
@@ -40,6 +40,9 @@ require("lazy").setup({
       -- disable some rtp plugins
       disabled_plugins = {
         "gzip",
+        "matchit",
+        "matchparen",
+        "netrwPlugin",
         "tarPlugin",
         "tohtml",
         "tutor",

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -103,7 +103,10 @@ bind-key -r -T prefix C-Right resize-pane -R 5
 unbind M-Left
 bind-key -r -T prefix C-Left resize-pane -L 5
 
-# layout shortcuts
+# layout shortcuts (unbind number keys to preserve window-jump)
+unbind 1
+unbind 2
+unbind 3
 bind F1 select-layout even-horizontal
 bind F2 select-layout even-vertical
 bind F3 select-layout main-vertical \; swap-pane -s 0 -t 1

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -104,9 +104,9 @@ unbind M-Left
 bind-key -r -T prefix C-Left resize-pane -L 5
 
 # layout shortcuts
-bind 1 select-layout even-horizontal
-bind 2 select-layout even-vertical
-bind 3 select-layout main-vertical \; swap-pane -s 0 -t 1
+bind F1 select-layout even-horizontal
+bind F2 select-layout even-vertical
+bind F3 select-layout main-vertical \; swap-pane -s 0 -t 1
 
 # List of plugins
 set -g @plugin 'tmux-plugins/tpm'

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -103,10 +103,7 @@ bind-key -r -T prefix C-Right resize-pane -R 5
 unbind M-Left
 bind-key -r -T prefix C-Left resize-pane -L 5
 
-# layout shortcuts (unbind number keys to preserve window-jump)
-unbind 1
-unbind 2
-unbind 3
+# layout shortcuts
 bind F1 select-layout even-horizontal
 bind F2 select-layout even-vertical
 bind F3 select-layout main-vertical \; swap-pane -s 0 -t 1

--- a/.config/yadm/bootstrap##distro.Ubuntu
+++ b/.config/yadm/bootstrap##distro.Ubuntu
@@ -79,11 +79,13 @@ mise prune --yes
 echo "Installing/updating tmuxinator..."
 "$(mise which gem)" install tmuxinator
 
-# install rust and cargo
+# install or update rust
 curl https://sh.rustup.rs -sSf | sh -s -- -y
+source "$HOME/.cargo/env"
+rustup update stable
 
 # install lua tools
-sudo luarocks install luacheck
+sudo luarocks --lua-version=5.4 install luacheck
 
 # install starship
 curl -sS https://starship.rs/install.sh | sh -s -- -y

--- a/.config/yadm/bootstrap##os.Darwin
+++ b/.config/yadm/bootstrap##os.Darwin
@@ -37,16 +37,21 @@ echo "Installing/updating Claude Code..."
 curl -fsSL https://claude.ai/install.sh | bash
 
 # in some cases after prettierd is updated, it needs to be restarted
-prettierd restart
+prettierd restart || true
 
 # install luacheck
 echo "Installing luacheck..."
-luarocks install luacheck
+luarocks --lua-version=5.4 install luacheck
 
 # turn off behavior to support accents when holding down key
 # https://stackoverflow.com/a/39733008/3112403
 echo "Turn off default Mac support for accents..."
 defaults write -g ApplePressAndHoldEnabled -bool false
+
+# install or update rust
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+source "$HOME/.cargo/env"
+rustup update stable
 
 # install mise (if not already via brew)
 if ! command -v mise >/dev/null 2>&1; then

--- a/.gitconfig
+++ b/.gitconfig
@@ -39,5 +39,7 @@
     st = status
     br = branch
     lg = log --oneline --decorate --all --graph
+[advice]
+    addIgnoredFile = false
 [include]
     path = .gitconfig.local

--- a/.nvim.lua
+++ b/.nvim.lua
@@ -1,4 +1,5 @@
 -- specify GIT_WORK_TREE for yadm so git integration works
 
 vim.env.GIT_DIR = vim.fn.expand("~/.local/share/yadm/repo.git")
+
 vim.env.GIT_WORK_TREE = vim.fn.expand("~")

--- a/.nvim.lua
+++ b/.nvim.lua
@@ -1,5 +1,4 @@
 -- specify GIT_WORK_TREE for yadm so git integration works
 
 vim.env.GIT_DIR = vim.fn.expand("~/.local/share/yadm/repo.git")
-
 vim.env.GIT_WORK_TREE = vim.fn.expand("~")


### PR DESCRIPTION
## Summary
- Quote lazygit `nerdFontsVersion` value to fix type warning
- Use `LazyVim.safe_keymap_set` instead of custom map wrapper in keymaps.lua
- Disable `matchit`, `matchparen`, and `netrwPlugin` rtp plugins for performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)