### PR TITLE
Add jinja-lsp support and remap Neo-tree custom actions

### DIFF
--- a/.config/lazyvim/lua/config/options.lua
+++ b/.config/lazyvim/lua/config/options.lua
@@ -15,3 +15,12 @@ vim.g.lazyvim_python_ruff = "ruff"
 -- Enable clipboard over SSH via OSC 52
 vim.opt.clipboard = "unnamedplus"
 
+-- register .j2 files as jinja filetype
+vim.filetype.add({
+  extension = {
+    j2 = "jinja",
+    jinja = "jinja",
+    jinja2 = "jinja",
+  },
+})
+

--- a/.config/lazyvim/lua/config/options.lua
+++ b/.config/lazyvim/lua/config/options.lua
@@ -15,10 +15,15 @@ vim.g.lazyvim_python_ruff = "ruff"
 -- Enable clipboard over SSH via OSC 52
 vim.opt.clipboard = "unnamedplus"
 
--- register .j2 files as jinja filetype
+-- register .j2 files as jinja filetype (.md.j2 stays as markdown)
 vim.filetype.add({
   extension = {
-    j2 = "jinja",
+    j2 = function(path)
+      if path:match("%.md%.j2$") then
+        return "markdown"
+      end
+      return "jinja"
+    end,
     jinja = "jinja",
     jinja2 = "jinja",
   },

--- a/.config/lazyvim/lua/plugins/lsp.lua
+++ b/.config/lazyvim/lua/plugins/lsp.lua
@@ -6,7 +6,7 @@ return {
       inlay_hints = { enabled = true },
       servers = {
         jinja_lsp = {
-          filetypes = { "jinja" },
+          filetypes = { "jinja", "markdown" },
         },
         basedpyright = {
           settings = {

--- a/.config/lazyvim/lua/plugins/lsp.lua
+++ b/.config/lazyvim/lua/plugins/lsp.lua
@@ -5,6 +5,9 @@ return {
       -- toggle hints on/off with <leader>uh
       inlay_hints = { enabled = true },
       servers = {
+        jinja_lsp = {
+          filetypes = { "jinja" },
+        },
         basedpyright = {
           settings = {
             basedpyright = {

--- a/.config/lazyvim/lua/plugins/neo_tree.lua
+++ b/.config/lazyvim/lua/plugins/neo_tree.lua
@@ -22,8 +22,10 @@ return {
     },
     window = {
       mappings = {
-        -- Copy relative path to clipboard (e.g., src/file.lua)
-        ["gy"] = {
+        -- Custom actions group
+        ["F"] = { "show_help", nowait = false, config = { title = "Custom Actions", prefix_key = "F" } },
+        -- Copy relative path to clipboard
+        ["Fy"] = {
           function(state)
             local node = state.tree:get_node()
             local path = vim.fn.fnamemodify(node:get_id(), ":.")
@@ -33,7 +35,7 @@ return {
           desc = "Copy Relative Path",
         },
         -- Live grep scoped to the selected directory
-        ["gg"] = {
+        ["Fg"] = {
           function(state)
             local path = get_node_dir(state)
             local rel_path = vim.fn.fnamemodify(path, ":~:.")
@@ -45,7 +47,7 @@ return {
           desc = "Grep in Directory",
         },
         -- Find files scoped to the selected directory
-        ["gf"] = {
+        ["Ff"] = {
           function(state)
             local path = get_node_dir(state)
             local rel_path = vim.fn.fnamemodify(path, ":~:.")
@@ -55,18 +57,6 @@ return {
             })
           end,
           desc = "Find Files in Directory",
-        },
-        -- Search symbols (LSP workspace symbols) scoped to the selected directory
-        ["gS"] = {
-          function(state)
-            local path = get_node_dir(state)
-            local rel_path = vim.fn.fnamemodify(path, ":~:.")
-            require("telescope.builtin").lsp_workspace_symbols({
-              search_dirs = { path },
-              prompt_title = "Symbols in " .. rel_path,
-            })
-          end,
-          desc = "Find Symbols in Directory",
         },
       },
     },

--- a/.config/lazyvim/lua/plugins/treesitter.lua
+++ b/.config/lazyvim/lua/plugins/treesitter.lua
@@ -1,0 +1,11 @@
+return {
+  {
+    "nvim-treesitter/nvim-treesitter",
+    opts = {
+      ensure_installed = {
+        "jinja",
+        "jinja_inline",
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- Add jinja-lsp with filetype detection for `.j2` files (`.md.j2` stays as markdown for proper highlighting)
- Add jinja and jinja_inline Tree-sitter parsers via `ensure_installed`
- Remap Neo-tree custom actions (`Fy`, `Fg`, `Ff`) under `F` prefix with built-in help popup, removing symbol search

## Test plan
- [ ] Open a `.j2` file and verify jinja-lsp attaches via `:LspInfo`
- [ ] Open a `.md.j2` file and verify both marksman and jinja-lsp attach
- [ ] Press `F` in Neo-tree and verify help popup shows custom actions
- [ ] Test `Fg` (grep), `Ff` (find files), `Fy` (copy path) in Neo-tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)