### PR TITLE
Add <leader>cx keymap to restart LSP servers

### DIFF
--- a/.config/lazyvim/lua/config/keymaps.lua
+++ b/.config/lazyvim/lua/config/keymaps.lua
@@ -81,6 +81,9 @@ end, {
 })
 map("n", "<leader>ghc", ":GitBase ", { desc = "Change Git Base", silent = false })
 
+-- Restart all LSP clients for the current buffer
+map("n", "<leader>cx", "<cmd>LspRestart<cr>", { desc = "󰜉 Restart LSP" })
+
 -- Keep cursor centered when moving 1/2 pages
 map("n", "<C-d>", "<C-d>zz")
 map("n", "<C-u>", "<C-u>zz")


### PR DESCRIPTION
## Summary
- Adds `<leader>cx` keymap to restart all LSP clients for the current buffer via `:LspRestart`
- Shows as "󰜉 Restart LSP" in which-key under the `+code` menu

## Test plan
- [ ] Open a Python file in LazyVim, press `<leader>c` and verify `x` appears in the which-key menu
- [ ] Press `<leader>cx` and confirm LSP restarts (notification should appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)