### PR TITLE
Fix Ubuntu bootstrap and keep C-a prefix in tmux mobile mode

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -204,7 +204,7 @@ bind -T off F12 \
     set -u prefix \;\
     set -u key-table \; source-file ~/.config/tmux/tmux.conf
 
-# === prefix + m: toggle mobile mode (C-b prefix, no indicators, 📱 badge) ===
+# === prefix + m: toggle mobile mode (simplified status, 📱 badge) ===
 bind m if -F '#{@mobile_mode}' \
     'source-file ~/.config/tmux/tmux.conf' \
-    'set -g @mobile_mode 1 ; set -g prefix C-b ; unbind C-a ; bind C-b send-prefix ; set -g status-left " 📱 " ; set -g status-right "#{?client_prefix,#[fg=#{@thm_peach}] ⚡#[default],}"'
+    'set -g @mobile_mode 1 ; set -g status-left " 📱 " ; set -g status-right "#{?client_prefix,#[fg=#{@thm_peach}] ⚡#[default],}"'

--- a/.ubuntu-packages##distro.Ubuntu
+++ b/.ubuntu-packages##distro.Ubuntu
@@ -34,6 +34,8 @@ libxext6
 libxml2-dev
 libxmlsec1-dev
 libxrender1
+liblua5.4-dev
+lua5.4
 luarocks
 mc
 net-tools


### PR DESCRIPTION
## Summary

- Add lua5.4 and liblua5.4-dev to the Ubuntu package list so `luarocks --lua-version=5.4 install luacheck` succeeds during bootstrap
- Remove prefix-swap from tmux mobile mode toggle now that the mobile client supports a customizable prefix on its side
- Keep the mobile mode 📱 badge and simplified status line since the display change is still useful