### PR TITLE
tmux: move session to status-left and fix copy-mode rectangle select

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -57,9 +57,6 @@ bind-key l select-pane -R
 bind -r n next-window
 bind -r p previous-window
 
-# bind "v" to enter visual mode, matching vim
-bind -T copy-mode-vi v send -X begin-selection
-
 # setup tmux vim-tmux-navigator
 # See: https://github.com/christoomey/vim-tmux-navigator
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
@@ -157,10 +154,10 @@ set -g status-position top
 run '~/.config/tmux/plugins/tmux/catppuccin.tmux'
 
 # status line
-set -g status-left ""
+set -g status-left '#{E:@catppuccin_status_session}'
+set -g status-left-length 100
 set -g status-right-length 100
 set -g  status-right "#{?client_prefix,#[fg=#{@thm_peach}] ⚡#[default],}"
-set -ag status-right '#{E:@catppuccin_status_session}'
 set -agF status-right '#{E:@catppuccin_status_cpu}'
 
 # load custom catppuccin module for tmux-scout


### PR DESCRIPTION
## Summary
- Move session indicator from status-right to status-left for better visibility
- Remove custom `v` binding in copy-mode-vi that was overriding the default rectangle-toggle behavior

## Test plan
- [ ] `prefix + r` to reload config
- [ ] Verify session name appears on the left side of the status bar
- [ ] Verify `v` toggles rectangle select in copy mode (`prefix + [`, `Space`, then `v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)