### PR TITLE
Pin neo-tree.nvim to avoid git_base regression

### DIFF
--- a/.config/lazyvim/lua/plugins/neo_tree.lua
+++ b/.config/lazyvim/lua/plugins/neo_tree.lua
@@ -10,6 +10,10 @@ end
 
 return {
   "nvim-neo-tree/neo-tree.nvim",
+  -- Pin to the commit before 4d0828d, which broke `:Neotree git_base=...` by
+  -- passing the coroutine `success` boolean into the diff callback instead of
+  -- the parsed status table (see git/init.lua:632 "attempt to index ... boolean").
+  commit = "aa3500f",
   dependencies = {
     "s1n7ax/nvim-window-picker",
   },


### PR DESCRIPTION
## Summary
- Pin `neo-tree.nvim` to commit `aa3500f` in `lua/plugins/neo_tree.lua`.
- Upstream commit `4d0828d` ("fix(git): handle nested worktrees properly", #2015) regressed `:Neotree git_base=<ref>`: the diff callback at `git/init.lua:409` now receives the coroutine `success` boolean instead of the parsed status table, which gets stored at `worktree.status_diff[base]` and later blows up at `git/init.lua:632` with `attempt to index local 'git_status' (a boolean value)`.
- Triggered locally via the `<leader>ghc` keymap (`:GitBase <ref>` → `:Neotree git_base=<ref>`).

## Test plan
- [ ] `:Lazy sync` (or `:Lazy restore neo-tree.nvim`) and confirm `git -C ~/.local/share/lazyvim/lazy/neo-tree.nvim rev-parse --short HEAD` prints `aa3500f`
- [ ] In a git repo, run `<leader>ghc master` and confirm no neo-tree warnings appear
- [ ] Confirm neo-tree still renders the file tree and git status markers correctly
- [ ] Revisit the pin once upstream ships a fix for #2015

🤖 Generated with [Claude Code](https://claude.com/claude-code)