### PR TITLE
lazygit: reuse current nvim tab on edit

### DIFF
--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -7,3 +7,5 @@ gui:
   nerdFontsVersion: "3"
 os:
   editPreset: "nvim"
+  edit: 'if [ -n "$NVIM" ]; then nvim --server "$NVIM" --remote "{{filename}}"; else nvim "{{filename}}"; fi'
+  editAtLine: 'if [ -n "$NVIM" ]; then nvim --server "$NVIM" --remote "{{filename}}"; else nvim "+{{line}}" "{{filename}}"; fi'


### PR DESCRIPTION
## Summary
- When lazygit's `e` (edit) is invoked from a terminal launched inside Neovim (`$NVIM` is set by `:terminal`), open the file in the existing Nvim instance via `nvim --server "$NVIM" --remote` instead of spawning a nested Nvim.
- Falls back to plain `nvim` (and `nvim "+<line>"` for `editAtLine`) when run outside an Nvim terminal.
- Avoids the nested-editor footgun where you'd otherwise end up with an Nvim inside an Nvim and have to `:q` your way back out.

## Test plan
- [ ] Inside Nvim: `:terminal lazygit`, press `e` on a file → file opens in a new buffer in the outer Nvim, lazygit returns to focus
- [ ] Inside Nvim: press `E` (or whatever `editAtLine` is bound to) on a hunk → file opens in the outer Nvim (note: line jump is not preserved in this path — see review notes)
- [ ] Outside Nvim (plain shell): `lazygit` → `e` → opens a fresh Nvim with the file
- [ ] Outside Nvim: `editAtLine` opens a fresh Nvim at the right line via `+<line>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)