### PR TITLE
lazyvim: switch diffview.nvim to dlyongemallo fork

### DIFF
--- a/.config/lazyvim/lua/plugins/diffview.lua
+++ b/.config/lazyvim/lua/plugins/diffview.lua
@@ -1,5 +1,5 @@
 return {
-  "sindrets/diffview.nvim",
+  "dlyongemallo/diffview.nvim",
   cmd = { "DiffviewOpen", "DiffviewFileHistory", "DiffviewClose" },
   keys = {
     { "<leader>go", ":DiffviewOpen ", desc = "DiffviewOpen" },


### PR DESCRIPTION
## Summary
- Switches the `diffview.nvim` plugin source from `sindrets/diffview.nvim` to the `dlyongemallo/diffview.nvim` fork in the LazyVim config.
- Keeps existing keybindings (`<leader>go`, `<leader>gq`), lazy-load triggers, and `winbar_info` opts unchanged — drop-in fork swap.

## Test plan
- [ ] `:Lazy sync` removes any stale clone and pulls the fork
- [ ] `cd ~/.local/share/nvim/lazy/diffview.nvim && git remote -v` shows `dlyongemallo/diffview.nvim`
- [ ] `<leader>go<CR>` opens DiffView against working tree vs HEAD
- [ ] `<leader>go HEAD~1<CR>` diffs against previous commit
- [ ] `<leader>gq` closes the DiffView tab
- [ ] `:DiffviewFileHistory` opens history view

🤖 Generated with [Claude Code](https://claude.com/claude-code)