### PR TITLE
Upgrade latest-pinned mise tools on every run

### DIFF
--- a/.config/yadm/bootstrap##distro.Arch
+++ b/.config/yadm/bootstrap##distro.Arch
@@ -38,6 +38,7 @@ fi
 eval "$(~/.local/bin/mise activate bash --shims)"
 
 mise install
+mise upgrade
 mise prune --yes
 
 # install tmuxinator — use mise-managed gem directly because mise's gem: backend

--- a/.config/yadm/bootstrap##distro.Ubuntu
+++ b/.config/yadm/bootstrap##distro.Ubuntu
@@ -72,6 +72,7 @@ fi
 eval "$(~/.local/bin/mise activate bash --shims)"
 
 mise install
+mise upgrade
 mise prune --yes
 
 # install tmuxinator — use mise-managed gem directly because mise's gem: backend

--- a/.config/yadm/bootstrap##os.Darwin
+++ b/.config/yadm/bootstrap##os.Darwin
@@ -65,6 +65,7 @@ fi
 eval "$(mise activate bash --shims)"
 
 mise install
+mise upgrade
 mise prune --yes
 
 # install tmuxinator — use mise-managed gem directly because mise's gem: backend


### PR DESCRIPTION
## Summary
- Adds `mise upgrade` between `mise install` and `mise prune --yes` in all three platform bootstrap scripts (Darwin, Ubuntu, Arch).
- Tools pinned to `"latest"` in `~/.config/mise/config.toml` (bun, ruby, every `pipx:*`, every `npm:*` including `@openai/codex`, eza, ripgrep, etc.) now refresh to the newest upstream version on every `yadm bootstrap`.
- Exact-version pins (`go = "1.22.2"`, `node = "22.22.0"`, `python = "3.13.12"`) are honored by `mise upgrade` and stay put.
- Motivation: today's bootstrap left codex stuck at 0.120.0 even though 0.128.0 was released; `mise install` only fills missing versions, never re-checks `latest`.

## Test plan
- [ ] `bash -n` passes on all three bootstrap scripts
- [ ] `mise upgrade --dry-run` lists outdated `latest` tools (e.g. `npm:@openai/codex`) and skips `go`/`node`/`python`
- [ ] `yadm bootstrap` runs cleanly and bumps `codex --version` to the newest release
- [ ] After bootstrap, `mise current go node python` still reports `1.22.2`, `22.22.0`, `3.13.12`
- [ ] Second consecutive `yadm bootstrap` is a no-op for mise upgrade (no churn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)