### PR TITLE
Codex setup

### DIFF
--- a/.codex/skills/dotfiles/SKILL.md
+++ b/.codex/skills/dotfiles/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: dotfiles
+description: Use this skill when working in the user's home directory on dotfiles managed by yadm, including shell, editor, git, tmux, package bootstrap, and platform-specific macOS or Ubuntu configuration.
+---
+
+## Home Directory Dotfiles Management (yadm)
+
+The execution of this skill indicates you're working in the user's home
+directory and using **yadm** for version control and management of dotfiles.
+
+### Repository Context
+
+- **Primary remote:** `origin` → `git@github.com:salimhamed/dotfiles.git`
+- **Base branch:** `main`
+- **yadm version:** 3.5.0
+
+---
+
+### Workflow Conventions
+
+#### 1. Branch Strategy
+
+- **Create feature branches** for each set of changes if a feature branch does
+  not already exist. Always ask before creating a new branch.
+- Feature branches should be created from the default `main` branch
+- Feature branch names should follow the naming convention:
+  `claude/<descriptive-name>`
+- Examples:
+  - `claude/nvim-config-update`
+  - `claude/zsh-aliases`
+  - `claude/tmux-keybindings`
+
+#### 2. Commit & Push Policy
+
+- **Auto-push after commit** to keep remote in sync
+- GPG signing is enabled (commits will be signed automatically)
+- Use concise commit messages that are no more than one line of text
+
+#### 3. Platform Scope
+
+- Both **Darwin (macOS)** and **Ubuntu** are supported
+- Use yadm alternate file suffixes: `##os.Darwin`, `##distro.Ubuntu`
+- When making changes, consider whether they should apply to both platforms or
+  just one. Shared logic goes in unsuffixed files; platform-specific logic goes
+  in alternate files
+
+---
+
+### Zsh Code Conventions
+
+You might be asked to modify `zsh` code. When doing so, use a function-specific
+prefix for all local variables to avoid conflicts with shell builtins,
+environment variables, and other functions.
+
+**Avoid these generic variable names:**
+
+- `path` - conflicts with `$PATH`
+- `name` - common collision
+- `status` - conflicts with `$?` semantics
+- `line`, `count`, `match`, `result`, `output`
+- `default`, `root`, `dir`, `file`
+- Single-letter variables: `d`, `f`, `n`, `i`
+
+**Pattern:** `<prefix>_<descriptive_name>`
+
+Here's an example function following this convention:
+
+```zsh
+wt_example() {
+    local wt_branch wt_path wt_status
+    wt_branch=$(git branch --show-current)
+    wt_path=$(git rev-parse --show-toplevel)
+    # ...
+}
+```
+
+### Key Files Reference
+
+#### Shell Configuration
+
+| File                                              | Purpose                                  |
+| ------------------------------------------------- | ---------------------------------------- |
+| `~/.zshrc##os.Darwin`                             | Main zsh config (macOS)                  |
+| `~/.zshrc##distro.Ubuntu`                         | Main zsh config (Ubuntu)                 |
+| `~/.zprofile##os.Darwin`                          | Login shell profile (macOS)              |
+| `~/.zprofile##distro.Ubuntu`                      | Login shell profile (Ubuntu)             |
+| `~/.config/zsh/lib/environment.zsh`               | Shared env vars (editor, lang, starship) |
+| `~/.config/zsh/lib/environment-platform.zsh##*`   | Platform-specific PATH and env vars      |
+| `~/.config/zsh/lib/aliases.zsh`                   | Shared aliases                           |
+| `~/.config/zsh/lib/aliases-platform.zsh##*`       | Platform-specific aliases (Darwin only)  |
+| `~/.config/zsh/lib/completion.zsh`                | Completion system init                   |
+| `~/.config/zsh/lib/completion-platform.zsh##*`    | Platform-specific completions            |
+| `~/.config/zsh/lib/history.zsh`                   | History settings                         |
+| `~/.config/zsh/lib/ssh-agent.zsh`                 | SSH agent (Darwin only)                  |
+| `~/.config/zsh/.zsh_plugins.txt`                  | Antidote plugin list                     |
+
+#### Editor Configuration
+
+| File                 | Purpose                                            |
+| -------------------- | -------------------------------------------------- |
+| `~/.config/lazyvim/` | LazyVim distribution (primary terinal text editor) |
+| `~/.ideavimrc`       | JetBrains IdeaVim (primary IDE)                    |
+| `~/.config/nvim/`    | Custom Neovim config (legacy)                      |
+| `~/.vimrc`           | Vim config (legacy)                                |
+
+#### Git & Tools
+
+| File                                           | Purpose             |
+| ---------------------------------------------- | ------------------- |
+| `~/.gitconfig`                                 | Main git config     |
+| `~/.gitconfig.local##os.Darwin,class.Personal` | Local git overrides |
+| `~/.tmux.conf`                                 | Tmux configuration  |
+| `~/.config/alacritty/alacritty.toml`           | Terminal config     |
+| `~/.config/starship/starship.toml`             | Prompt config       |
+
+#### Bootstrap & Packages
+
+| File                                      | Purpose                     |
+| ----------------------------------------- | --------------------------- |
+| `~/.config/yadm/bootstrap##os.Darwin`     | macOS setup script          |
+| `~/.config/yadm/bootstrap##distro.Ubuntu` | Ubuntu setup script         |
+| `~/.Brewfile`                             | Homebrew packages (macOS)   |
+| `~/.ubuntu-packages`                      | apt packages (Ubuntu)       |
+
+---
+
+### Standard Operations
+
+#### Before Making Changes
+
+```bash
+yadm status                    # Check current state
+yadm diff                      # Review any uncommitted changes
+yadm branch -a                 # Verify branch context
+```
+
+#### Creating a Feature Branch
+
+```bash
+yadm checkout -b claude/<feature-description>
+```
+
+#### After Modifications
+
+```bash
+yadm add -f <files>            # Stage specific files (-f required due to catch-all .gitignore)
+yadm status                    # Verify staged changes
+yadm commit -m "description"   # Commit (auto-signed)
+yadm push -u origin HEAD       # Push and set upstream
+```
+
+> **Note:** `~/.gitignore` has a catch-all `*` rule to prevent slow `git status`
+> scans of the home directory. This means `yadm add` will refuse to stage files
+> unless you use `yadm add -f` (force). This does not affect already-tracked files.
+
+#### Viewing Tracked Files
+
+```bash
+yadm list -a                   # All tracked files
+yadm list -a | grep <pattern>  # Filter tracked files
+```
+
+---
+
+### Using `gh` CLI with yadm
+
+yadm stores its git data in a non-standard location (`~/.local/share/yadm/repo.git`
+with `$HOME` as the work tree). The `gh` CLI cannot auto-detect the repo, so
+commands like `gh pr view` or `gh pr create` will fail with
+`fatal: not a git repository`.
+
+**Always set these env vars when running `gh` commands:**
+
+```bash
+GIT_DIR="$HOME/.local/share/yadm/repo.git" GIT_WORK_TREE="$HOME" gh pr view
+```
+
+Alternatively, use `--repo salimhamed/dotfiles` to bypass local repo detection
+(works for commands that accept it, but not all do):
+
+```bash
+gh pr list --repo salimhamed/dotfiles
+```
+
+**Prefer the env var approach** — it works universally with all `gh` subcommands.
+
+---
+
+### Safety Practices
+
+1. **Always read before editing** - Use Read tool before making modifications
+2. **Stage specific files** - Never run `yadm add -A` in home directory
+3. **Verify changes** - Run `yadm diff --staged` before committing
+4. **Keep commits atomic** - One logical change per commit
+
+---
+
+### Verification Methods
+
+#### Shell Changes
+
+```bash
+source ~/.zshrc                # Reload zsh config
+# Or open new terminal tab
+```
+
+#### Neovim Changes
+
+```bash
+nvim --headless +checkhealth +qa  # Check nvim health
+nvim -c "echo 'Config loaded'" -c qa  # Quick load test
+```
+
+#### Git Config Changes
+
+```bash
+git config --list              # Verify effective config
+```
+
+#### Bootstrap Changes
+
+```bash
+# Dry-run review only - don't execute without explicit request
+bash -n ~/.config/yadm/bootstrap  # Syntax check
+```
+
+---
+
+### Quick Commands
+
+| Task                | Command                      |
+| ------------------- | ---------------------------- |
+| Check status        | `yadm status`                |
+| List tracked files  | `yadm list -a`               |
+| Show recent history | `yadm log --oneline -10`     |
+| View remotes        | `yadm remote -v`             |
+| Show current branch | `yadm branch --show-current` |
+| Diff uncommitted    | `yadm diff`                  |
+| Push current branch | `yadm push`                  |

--- a/.config/lazyvim/lua/config/autocmds.lua
+++ b/.config/lazyvim/lua/config/autocmds.lua
@@ -7,12 +7,14 @@
 vim.filetype.add({ pattern = { ["%.env"] = "dotenv", ["%.env%..*"] = "dotenv" } })
 vim.treesitter.language.register("bash", "dotenv")
 
--- Reduce visual noise for Claude Code temporary prompt files
+-- Reduce visual noise for AI tool temporary files (Claude Code, Codex, etc.)
 vim.api.nvim_create_autocmd("BufReadPost", {
-  group = vim.api.nvim_create_augroup("claude_prompt_files", { clear = true }),
+  group = vim.api.nvim_create_augroup("ai_tool_temp_files", { clear = true }),
   callback = function(args)
     local buf_name = vim.api.nvim_buf_get_name(args.buf)
-    if buf_name:match("/claude%-prompt%-.+%.md$") then
+    local is_claude = buf_name:match("/claude%-prompt%-.+%.md$")
+    local is_codex = buf_name:match("/private/var/folders/.+/T/%.tmp.+%.md$")
+    if is_claude or is_codex then
       vim.diagnostic.enable(false, { bufnr = args.buf })
       local ok, incline = pcall(require, "incline")
       if ok and incline.is_enabled() then

--- a/.config/zsh/lib/environment.zsh
+++ b/.config/zsh/lib/environment.zsh
@@ -23,6 +23,7 @@ export VIRTUAL_ENV_DISABLE_PROMPT=1
 # Claude Code
 export ENABLE_TOOL_SEARCH=true
 export ENABLE_EXPERIMENTAL_MCP_CLI=false
+export ENABLE_CLAUDEAI_MCP_SERVERS=false
 
 # Man pages with bat/batcat when available
 if command -v bat &>/dev/null; then


### PR DESCRIPTION
## Summary

- Extends the existing LazyVim autocmd that suppresses markdown diagnostics for Claude Code temp files to also cover Codex temp files
- Codex creates temp markdown files in `/private/var/folders/.../T/.tmp*.md` — these now get the same treatment (diagnostics disabled, incline plugin disabled)
- Renamed the augroup from `claude_prompt_files` → `ai_tool_temp_files` to reflect broader scope

## Test plan

- [ ] Open LazyVim, run `:autocmd BufReadPost` and confirm `ai_tool_temp_files` group exists
- [ ] Open a Codex temp-style file and confirm no markdown diagnostics appear
- [ ] Open a Claude Code prompt file and confirm existing behavior is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)