### PR TITLE
tmux: pass Shift+Enter through to CLI tools

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -11,6 +11,9 @@ set-option -ga terminal-overrides ",xterm-256color:Tc"
 set -s extended-keys on
 set -as terminal-features 'xterm*:extkeys'
 
+# Pass Shift+Enter through to CLI tools (e.g., Codex, Claude Code)
+bind -n S-Enter send-keys Escape Enter
+
 # Enable OSC 52 clipboard (tmux copy-mode emits OSC 52, inner apps forwarded)
 set -s set-clipboard on
 


### PR DESCRIPTION
## Summary
- Add tmux keybinding (`bind -n S-Enter send-keys Escape Enter`) to forward Shift+Enter to CLI tools like Codex and Claude Code
- Without this, tmux intercepts the escape sequence and Shift+Enter doesn't work inside tmux sessions

## Test plan
- [x] Reload tmux config with `prefix + r`
- [x] Verify Shift+Enter works in Codex inside tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)